### PR TITLE
Push to fabric8/launcher-documentation dockerhub

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -2,12 +2,12 @@
 
 GENERATOR_DOCKER_HUB_USERNAME=openshiftioadmin
 REGISTRY_URI="push.registry.devshift.net"
-REGISTRY_NS="openshiftio"
-REGISTRY_IMAGE="appdev-documentation"
+REGISTRY_NS="fabric8"
+REGISTRY_IMAGE="launcher-documentation"
 REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
-BUILDER_IMAGE="appdev-documentation-builder"
-BUILDER_CONT="appdev-documentation-builder-container"
-DEPLOY_IMAGE="appdev-documentation-deploy"
+BUILDER_IMAGE="launcher-documentation-builder"
+BUILDER_CONT="launcher-documentation-builder-container"
+DEPLOY_IMAGE="launcher-documentation-deploy"
 
 TARGET_DIR="html"
 

--- a/cico_build_test.sh
+++ b/cico_build_test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-BUILDER_IMAGE="appdev-documentation-builder"
-BUILDER_CONT="appdev-documentation-builder-container"
-DEPLOY_IMAGE="appdev-documentation-deploy"
+BUILDER_IMAGE="launcher-documentation-builder"
+BUILDER_CONT="launcher-documentation-builder-container"
+DEPLOY_IMAGE="launcher-documentation-deploy"
 TARGET_DIR="html"
 
 # Exit on error

--- a/openshift/launcher-documentation-configmap.yaml
+++ b/openshift/launcher-documentation-configmap.yaml
@@ -1,7 +1,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: appdev-documentation-configmap
+  name: launcher-documentation-configmap
   annotations:
     openshift.io/display-name: "Appdev Documentation - Configuration"
     description: This application contains the Appdev Documentation configuration settings
@@ -9,11 +9,11 @@ metadata:
     iconClass: icon-shadowman
     template.openshift.io/long-description: This application contains the Appdev Documentation configuration settings
     template.openshift.io/provider-display-name: Red Hat, Inc.
-    template.openshift.io/documentation-url: https://github.com/openshiftio/launchpad-templates
+    template.openshift.io/documentation-url: https://github.com/fabric8-launcher/launcher-openshift-templates
     template.openshift.io/support-url: https://access.redhat.com
 message: "The following service has been created in your project: launchpad-configuration.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/openshiftio"
 labels:
-  template: appdev-documentation-configmap
+  template: launcher-documentation-configmap
 parameters:
 - name: LAUNCHPAD_TRACKER_SEGMENT_TOKEN
   displayName: Segment Token
@@ -23,6 +23,6 @@ objects:
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-    name: appdev-documentation
+    name: launcher-documentation
   data:
     tracker.segment.token: ${LAUNCHPAD_TRACKER_SEGMENT_TOKEN}

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,21 +1,21 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: appdev-documentation
+  name: launcher-documentation
   annotations:
-    openshift.io/display-name: "Appdev - Documentation"
+    openshift.io/display-name: "Launcher - Documentation"
     description: This application contains the https://developers.redhat.com/launch documentation
     tags: instant-app,launchpad, documentation
     iconClass: icon-shadowman
     template.openshift.io/long-description: This application contains the Appdev documentation
     template.openshift.io/provider-display-name: Red Hat, Inc.
-    template.openshift.io/documentation-url: https://github.com/openshiftio
+    template.openshift.io/documentation-url: https://github.com/fabric8-launcher
     template.openshift.io/support-url: https://access.redhat.com
 labels:
-  template: appdev-documentation
+  template: launcher-documentation
 parameters:
 - name: IMAGE
-  value: openshiftio/appdev-documentation
+  value: fabric8/launcher-documentation
   required: true
 - name: IMAGE_TAG
   value: latest
@@ -24,11 +24,11 @@ objects:
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:
-    name: appdev-documentation
+    name: launcher-documentation
   spec:
     replicas: 1
     selector:
-      service: appdev-documentation
+      service: launcher-documentation
     strategy:
       resources: {}
       rollingParams:
@@ -41,17 +41,17 @@ objects:
     template:
       metadata:
         labels:
-          service: appdev-documentation
+          service: launcher-documentation
       spec:
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
-          name: appdev-documentation
+          name: launcher-documentation
           env:
           - name: LAUNCHPAD_TRACKER_SEGMENT_TOKEN
             valueFrom:
               configMapKeyRef:
-                name: appdev-documentation
+                name: launcher-documentation
                 key: tracker.segment.token
           ports:
           - containerPort: 8080
@@ -87,8 +87,8 @@ objects:
   apiVersion: v1
   metadata:
     labels:
-      service: appdev-documentation
-    name: appdev-documentation
+      service: launcher-documentation
+    name: launcher-documentation
   spec:
     ports:
     - name: "8080"
@@ -96,6 +96,6 @@ objects:
       protocol: TCP
       targetPort: 8080
     selector:
-      service: appdev-documentation
+      service: launcher-documentation
     sessionAffinity: None
     type: ClusterIP


### PR DESCRIPTION
This should push to fabric8/launcher-documentation instead of openshiftio/appdev-documentation