### PR TITLE
fix broken xref

### DIFF
--- a/docs/topics/vertx-community-and-product-versions.adoc
+++ b/docs/topics/vertx-community-and-product-versions.adoc
@@ -8,7 +8,6 @@ Supported {Vertx} runtime artifacts are available in the link:https://maven.repo
 
 .Technology Preview {Vertx} Components
 
-Technology Preview {Vertx} components included with {ProductShortName} are subject to the xref:vertx-tech-preview-components[Technology Preview Features Support Scope^] and are not supported.
+Technology Preview {Vertx} components included with {ProductShortName} are not supported. The supportability of these components is defined by the link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope^].
 
-//RN link TBD
 For a complete list of supported and Technology Preview {Vertx} components available with this release of {ProductShortName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/#rn-runtime-components-vertx[Release Notes^].


### PR DESCRIPTION
@rhoads-zach I replaced the busted xref with a link. This should stop the upstream builds from breaking.