### PR TITLE
WildFly Swarm application remote debugging (RHOARDOC-1131)

### DIFF
--- a/docs/topics/proc_attaching-a-remote-debugger-to-the-application.adoc
+++ b/docs/topics/proc_attaching-a-remote-debugger-to-the-application.adoc
@@ -1,0 +1,33 @@
+
+[#attaching-a-remote-debugger-to-the-application]
+= Attaching a Remote Debugger to the Application
+
+When your application is configured for debugging, attach a remote debugger of your choice to it.
+In this guide, xref:https://www.redhat.com/en/technologies/jboss-middleware/developer-studio[Red Hat JBoss Developer Studio] is covered, but the procedure is similar when using other programs.
+
+.Prerequisites
+
+* The application running either locally or on OpenShift, and configured for debugging.
+* The port number that your application is listening on for debugging.
+* Red Hat JBoss Developer Studio installed on your machine. You can download it from the xref:https://developers.redhat.com/products/devstudio/download/[Red Hat JBoss Developer Studio download page].
+
+.Procedure
+
+. Start Red Hat JBoss Developer Studio.
+. Create a new debug configuration for your application:
+.. Click *Run->Debug Configurations*.
+.. In the list of configurations, double-click *Remote Java application.*
+This creates a new remote debugging configuration.
+.. Enter a suitable name for the configuration in the *Name* field.
+.. Enter the path to the directory with your application into the *Project* field. You can use the *Browse...* button for convenience.
+.. Set the *Connection Type* field to _Standard (Socket Attach)_ if it is not already.
+.. Set the *Port* field to the port number that your application is listening on for debugging.
+.. Click *Apply.*
+. Start debugging by clicking the *Debug* button in the Debug Configurations window.
++
+To quickly launch your debug configuration after the first time, click *Run->Debug History* and select the configuration from the list.
+
+.Related Information
+
+* link:https://access.redhat.com/articles/1290703[Debug an OpenShift Java Application with JBoss Developer Studio] on Red Hat Knowledgebase.
+* A https://blog.openshift.com/debugging-java-applications-on-openshift-kubernetes/[Debugging Java Applications On OpenShift and Kubernetes] article on OpenShift Blog.

--- a/docs/topics/proc_starting-an-uberjar-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-an-uberjar-in-debugging-mode.adoc
@@ -1,0 +1,36 @@
+// This is a parameterized module. Parameters used:
+//
+//  parameter-uberjar-documented: Set if the current runtime has the chapter about creating uberjars
+//
+// Rationale: This procedure is identical in multiple Java-based deployments.
+
+[#starting-an-uberjar-in-debugging-mode]
+= Starting an Uberjar in Debugging Mode
+
+If you chose to package your application as a {runtime} uberjar, debug it by executing it with the following parameters.
+
+.Prerequisites
+
+* An uberjar with your application
+
+.Procedure
+
+. In a console, navigate to the directory with the uberjar.
+. Execute the uberjar with the following parameters.
+Ensure that all the parameters are specified before the name of the uberjar on the line.
++
+--
+[source,bash,options="nowrap"]
+----
+$ java -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=$PORT_NUMBER -jar $UBERJAR_FILENAME
+----
+
+Here, `$PORT_NUMBER` is an unused port number of your choice.
+Remember this number for the remote debugger configuration.
+--
+
+ifdef::parameter-uberjar-documented[]
+.Related Information
+
+* xref:creating-an-uberjar[]
+endif::[]

--- a/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
@@ -1,0 +1,31 @@
+
+[#starting-your-application-locally-in-debugging-mode_{context}]
+= Starting Your Application Locally in Debugging Mode
+
+One of the ways of debugging a Maven-based project is manually launching the application while specifying a debugging port, and subsequently connecting a remote debugger to that port.
+This method is applicable at least to the following deployments of the application:
+
+* When launching the application manually using the `mvn wildfly-swarm:run` goal.
+* When starting the application without waiting for the it to exit using the `mvn wildfly-swarm:start` goal.
+This is useful especially when performing integration testing.
+* When using the Arquillian adapter for {runtime}.
+
+.Prerequisites
+
+* A Maven-based application
+
+.Procedure
+
+. In a console, navigate to the directory with your application.
+. Launch your application and specify the debug port using the `-Dswarm.debug.port` argument:
++
+--
+[source,bash,options="nowrap"]
+----
+$ mvn wildfly-swarm:run -Dswarm.debug.port=$PORT_NUMBER
+----
+
+Here, `$PORT_NUMBER` is an unused port number of your choice.
+Remember this number for the remote debugger configuration.
+--
+

--- a/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
@@ -1,0 +1,64 @@
+
+[#starting-your-application-on-openshift-in-debugging-mode_{context}]
+= Starting Your Application on OpenShift in Debugging Mode
+
+To debug your {runtime}-based application on OpenShift remotely, you must set the `JAVA_DEBUG` environment variable inside the container to `true` and configure port forwarding so that you can connect to your application from a remote debugger.
+
+.Prerequisites
+
+* Your application running on OpenShift.
+* The `oc` binary installed on your machine.
+
+.Procedure
+
+. Using the `oc` command, list the available deployment configurations:
++
+[source,bash]
+----
+$ oc get dc
+----
+
+. Set the `JAVA_DEBUG` environment variable in the deployment configuration of your application to `true`, which configures the JVM to open the port number 5005 for debugging. For example:
++
+[source,bash]
+----
+$ oc set env dc/my-application JAVA_DEBUG=true
+----
+
+. Redeploy the application if it is not set to redeploy automatically on environment change. For example:
++
+[source,bash]
+----
+$ oc rollout latest dc/my-application
+----
+
+. Configure port forwarding from your local machine to the application pod:
+.. List the currently running pods and find one containing your application:
++
+[source,bash,options="nowrap"]
+----
+$ oc get pod
+NAME                            READY     STATUS      RESTARTS   AGE
+my-application-3-1xrsp          0/1       Running     0          6s
+...
+----
+
+.. Configure port forwarding:
++
+--
+[source,bash,options="nowrap"]
+----
+$ oc port-forward my-application-3-1xrsp $LOCAL_PORT_NUMBER:5005
+----
+
+Here, `$LOCAL_PORT_NUMBER` is an unused port number of your choice on your local machine.
+Remember this number for the remote debugger configuration.
+--
+
+. When you are done debugging, unset the `JAVA_DEBUG` environment variable in your application pod. For example:
++
+[source,bash]
+----
+$ oc set env dc/my-application JAVA_DEBUG-
+----
+

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -41,7 +41,25 @@ This sections contains information about packaging your {WildFlySwarm}&ndash;bas
 include::topics/wildfly-swarm/docs/concepts/packaging-types.adoc[leveloffset=+2]
 include::topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc[leveloffset=+2]
 
+== Debugging
 
+This sections contains information about debugging your {WildFlySwarm}&ndash;based application both in local and remote deployments.
+
+=== Remote Debugging
+
+To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
+
+include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[leveloffset=+3]
+
+:parameter-uberjar-documented:
+include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
+:parameter-uberjar-documented!:
+
+include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
+
+include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]
+
+// MISSIONS
 include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
 [[mission-http-api-wf-swarm]]


### PR DESCRIPTION
This content documents remote debugging with WildFly Swarm. A lot of it can possibly be reused by Vert.x and Spring Boot; can you please assess the reusability, @inoxx03 @lavernw1? Thank you.

If the reusability is low, I will close this pull request and rather submit it to the WFS upstream (with appropriate changes).

I will squash the commits once I get the green light with the changes.