### PR TITLE
Fixes # RHOARDOC-126 add dev links (github 976)

### DIFF
--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -215,6 +215,9 @@ include::topics/http-api-nodejs-package-json.adoc[leveloffset=+1]
 include::topics/nodejs-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
+include::topics/appendix-application-development-resources.adoc[leveloffset=+1]
+
+[appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
 
 [appendix]
@@ -222,4 +225,3 @@ include::topics/appendix-nodeshift.adoc[leveloffset=+1]
 
 [appendix]
 include::topics/appendix-glossary.adoc[leveloffset=+1]
-

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -255,6 +255,9 @@ include::topics/appendix-using-war-files-spring-boot.adoc[leveloffset=+1]
 include::topics/sb-tomcat-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
+include::topics/appendix-application-development-resources.adoc[leveloffset=+1]
+
+[appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
 
 [appendix]

--- a/docs/topics/appendix-application-development-resources.adoc
+++ b/docs/topics/appendix-application-development-resources.adoc
@@ -1,0 +1,7 @@
+[[application-development-resources]]
+= Application Development Resources
+
+For additional information on application development with OpenShift see:
+
+* link:https://learn.openshift.com/[OpenShift Interactive Learning Portal]
+* link:https://developers.redhat.com/products/rhoar/overview/[Red Hat OpenShift Application Runtimes Overview]

--- a/docs/topics/wf-swarm-dev-guide-additional-resources.adoc
+++ b/docs/topics/wf-swarm-dev-guide-additional-resources.adoc
@@ -6,3 +6,4 @@
 * link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/v/{WildFlySwarmVersion}/[{WildFlySwarm} User Guide]
 * link:https://github.com/wildfly-swarm/wildfly-swarm-presentations[{WildFlySwarm} Presentations]
 * link:https://github.com/redhat-Microservices/lab_swarm-openshift[{WildFlySwarm}, Microservices & OpenShift Lab]
+* link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/wildfly_swarm_microservices_on_red_hat_openshift_container_platform_3/[{WildFlySwarm} Microservices On Red Hat OpenShift Container Platform 3]

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -260,6 +260,9 @@ include::topics/appendix-s2i-build-process.adoc[leveloffset=+1]
 include::topics/vertx-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
+include::topics/appendix-application-development-resources.adoc[leveloffset=+1]
+
+[appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
 
 [appendix]

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -281,6 +281,9 @@ endif::[]
 include::topics/wf-swarm-dev-guide-additional-resources.adoc[leveloffset=+1]
 
 [appendix]
+include::topics/appendix-application-development-resources.adoc[leveloffset=+1]
+
+[appendix]
 include::topics/appendix-proficiency-levels.adoc[leveloffset=+1]
 
 [appendix]


### PR DESCRIPTION
@rhoads-zach @tradej @inoxx03 @Ladicek Fixes for RHOARDOC-126 Update Mission Proficiencies.  
No changes to mission proficiency descriptions. No consensus to do that at this time.
Added appendix Application Development Resources (for developing appls on OpenShift )  
Added reference architecture reference to WildFly Swarm resources
