### PR TITLE
Live debugging reuse fix

### DIFF
--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -16,6 +16,23 @@ include::topics/sb-product-versions.adoc[leveloffset=+2]
 
 include::topics/sb-features-and-frameworks-summary.adoc[leveloffset=+2]
 
+== Debugging
+
+This sections contains information about debugging your {SpringBoot}&#x2013;based application both in local and remote deployments.
+
+=== Remote Debugging
+:context: remote-debugging
+
+To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
+
+include::topics/proc_starting-your-spring-boot-application-locally-in-debugging-mode.adoc[leveloffset=+3]
+
+include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
+
+include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
+
+include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]
+
 == Monitoring
 
 This section contains information about monitoring your {SpringBoot}&#x2013;based application running on OpenShift.

--- a/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
@@ -17,8 +17,8 @@ ifdef::wf-swarm[]
 * When launching the application manually using the `mvn {parameter-maven-goal}` goal.
 * When starting the application without waiting for it to exit using the `mvn wildfly-swarm:start` goal.
 This is useful especially when performing integration testing.
-endif::[]
 * When using the Arquillian adapter for {runtime}.
+endif::[]
 
 .Prerequisites
 

--- a/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
@@ -1,19 +1,20 @@
+// This is a parameterized module. Parameters used:
+//
+//   parameter-debug-property: The Java application property used to specify the debug port
+//   parameter-maven-goal: Name of the runtime and the goal for executing debugging, e. g. "vertx:run"
+//
+// Rationale: This procedure is identical in Swarm and Vert.x
+
+
 [#starting-your-application-locally-in-debugging-mode_{context}]
 = Starting Your Application Locally in Debugging Mode
 
 One of the ways of debugging a Maven-based project is manually launching the application while specifying a debugging port, and subsequently connecting a remote debugger to that port.
 This method is applicable at least to the following deployments of the application:
 
+ifdef::vert-x[* When launching the application manually using the `mvn {parameter-maven-goal}` goal. This starts the application with debugging enabled.]
 ifdef::wf-swarm[]
-* When launching the application manually using the `mvn wildfly-swarm:run`goal.
-endif::[]
-ifdef::vertx[]
-* When launching the application manually using the `mvn vertx:debug` goal. This starts the application with debugging enabled.
-endif::[]
-ifdef::spring-boot[]
-* When launching the application manually using the `mvn spring-boot:run`goal.
-endif::[]
-ifdef::wf-swarm[]
+* When launching the application manually using the `mvn {parameter-maven-goal}` goal.
 * When starting the application without waiting for it to exit using the `mvn wildfly-swarm:start` goal.
 This is useful especially when performing integration testing.
 endif::[]
@@ -26,36 +27,17 @@ endif::[]
 .Procedure
 
 . In a console, navigate to the directory with your application.
-ifdef::wf-swarm[]
-. Launch your application and specify the debug port using the `-Dswarm.debug.port` argument:
-endif::[]
-ifdef::vertx[]
-. Launch your application and specify the debug port using the `-Ddebug.port` argument:
-endif::[]
-ifdef::spring-boot[]
-. Launch your application and specify the debug port using the `-Dspring-boot.debug.port` argument:
-endif::[]
+. Launch your application and specify the debug port using the `-D{parameter-debug-property}` argument:
 +
-ifdef::wf-swarm[]
-[source,bash,options="nowrap"]
+--
+[source,bash,options="nowrap",subs="attributes+"]
 ----
-$ mvn wildfly-swarm:run -Dswarm.debug.port=$PORT_NUMBER
+$ mvn {parameter-maven-goal} -D{parameter-debug-property}=$PORT_NUMBER
 ----
-endif::[]
-ifdef::vertx[]
-[source,bash,options="nowrap"]
-----
-$ mvn vertx:debug -Ddebug.port=$PORT_NUMBER
-----
-+
-Use the `-Ddebug.suspend=true` argument to make the application wait until a debugger is attached to start.
-endif::[]
-ifdef::spring-boot[]
-[source,bash,options="nowrap"]
-----
-$ mvn spring-boot:run -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT_NUMBER"
-----
-endif::[]
 
 Here, `$PORT_NUMBER` is an unused port number of your choice.
 Remember this number for the remote debugger configuration.
+
+ifdef::vert-x[Use the `-Ddebug.suspend=true` argument to make the application wait until a debugger is attached to start.]
+--
+

--- a/docs/topics/proc_starting-your-spring-boot-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-spring-boot-application-locally-in-debugging-mode.adoc
@@ -1,0 +1,28 @@
+[#starting-your-spring-boot-application-locally-in-debugging-mode]
+= Starting Your {SpringBoot} Application Locally in Debugging Mode
+
+One of the ways of debugging a Maven-based project is manually launching the application while specifying a debugging port, and subsequently connecting a remote debugger to that port.
+This method is applicable at least to the following deployments of the application:
+
+* When launching the application manually using the `mvn spring-boot:run` goal.
+* When using the Arquillian adapter for {runtime}.
+
+.Prerequisites
+
+* A Maven-based application
+
+.Procedure
+
+. In a console, navigate to the directory with your application.
+. Launch your application and specify the necessary JVM arguments and the debug port using the following syntax:
++
+--
+[source,bash,options="nowrap"]
+----
+$ mvn spring-boot:run -Drun.jvmArguments="-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT_NUMBER"
+----
+
+Here, `$PORT_NUMBER` is an unused port number of your choice.
+Remember this number for the remote debugger configuration.
+--
+

--- a/docs/topics/proc_starting-your-spring-boot-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-spring-boot-application-locally-in-debugging-mode.adoc
@@ -2,10 +2,7 @@
 = Starting Your {SpringBoot} Application Locally in Debugging Mode
 
 One of the ways of debugging a Maven-based project is manually launching the application while specifying a debugging port, and subsequently connecting a remote debugger to that port.
-This method is applicable at least to the following deployments of the application:
-
-* When launching the application manually using the `mvn spring-boot:run` goal.
-* When using the Arquillian adapter for {runtime}.
+This method is applicable at least when launching the application manually using the `mvn spring-boot:run` goal.
 
 .Prerequisites
 

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -2,7 +2,7 @@ include::topics/templates/document-attributes.adoc[]
 
 //override for a cleaner TOC
 :toclevels: 2
-:vertx:
+:vert-x:
 
 = {vertx-runtime-guide-name}
 :runtime: {VertX}

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -36,7 +36,11 @@ This sections contains information about debugging your {WildFlySwarm}&#x2013;ba
 To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
 
 
+:parameter-debug-property: debug.port
+:parameter-maven-goal: vertx:debug
 include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[leveloffset=+3]
+:parameter-debug-property!:
+:parameter-maven-goal!:
 
 //:parameter-uberjar-documented:
 //include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -28,7 +28,7 @@ include::topics/configuring-vertx.adoc[leveloffset=+2]
 
 == Debugging
 
-This sections contains information about debugging your {WildFlySwarm}&#x2013;based application both in local and remote deployments.
+This sections contains information about debugging your {VertX}&#x2013;based application both in local and remote deployments.
 
 === Remote Debugging
 :context: 

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -50,7 +50,11 @@ This sections contains information about debugging your {WildFlySwarm}&#x2013;ba
 
 To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
 
+:parameter-debug-property: swarm.debug.port
+:parameter-maven-goal: wildfly-swarm:run
 include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[leveloffset=+3]
+:parameter-debug-property!:
+:parameter-maven-goal!:
 
 :parameter-uberjar-documented:
 include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]


### PR DESCRIPTION
I took the liberty to do some alterations to the local debugging content:

* The original WFS is now shared only between WFS and Vert.x. Spring Boot uses different arguments and a different syntax, so there was already too much conditionalising. The module is now parameterised too.
* I have changed the `:vertx:` runtime attribute to `:vert-x:` because it clashed with `:VertX:`. That meant that the `ifdef::vertx` clause evaluated to _True_ in all the runtime guides, making it useless.
* I have written a Spring Boot–specific variant of the local debugging file and included it in Spring Boot's `master.adoc` file. Other live debugging–related files are also included, but I am not sure if we want to include the uberjar-related content since it is not mentioned anywhere else in the guide.

This PR supersedes #999.