### PR TITLE
ENTSWM-220 + Arquillian testing for WFS

### DIFF
--- a/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
@@ -22,6 +22,30 @@ include::pom.xml[tag=bom,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
+
+ifdef::product[]
+. If your test uses the Apache HTTP Client or the JAX-RS Client, add the `commons-logging` artifact to the `test` scope of the project in the `pom.xml` file:
++
+--
+[source,xml]
+----
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    <dependency>
+  </dependencies>
+</project>
+----
+
+The reason is that the WildFly Swarm productized rutime artifact BOM imports the EAP runtime artifacts BOM (`org.jboss.bom:eap-runtime-artifacts`), which excludes the `commons-logging` artifact from the `org.apache.httpcomponents:httpclient` and `org.apache.james:apache-mime4j` artifacts.
+As a result, when running tests in a Maven project that imports the WildFly Swarm productized runtime artifact BOM, neither the Apache HTTP Client nor any other artifact that depends on it (for example, the JAX-RS Client) works.
+--
+endif::[]
+
 . Reference the `org.wildfly.swarm:arquillian` artifact in your `pom.xml` file
 with the `<scope>` set to `test`:
 +

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -42,6 +42,10 @@ This sections contains information about packaging your {WildFlySwarm}&#x2013;ba
 include::topics/wildfly-swarm/docs/concepts/packaging-types.adoc[leveloffset=+2]
 include::topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc[leveloffset=+2]
 
+== Testing
+
+include::topics/wildfly-swarm/docs/howto/test-in-container/index.adoc[leveloffset=+2]
+
 == Debugging
 
 This sections contains information about debugging your {WildFlySwarm}&#x2013;based application both in local and remote deployments.


### PR DESCRIPTION
As we include the information about the users having to include `commons-logging` in the Release Notes, we should have it in the main docs as well. In the upstream, the warning is included in the _Testing in container_ chapter. I believe the chapter in question is ready style-wise, but please check [the entire file](https://github.com/tradej/appdev-documentation/blob/0f602357ad2d4b44dd573cb77f20bf056c713523/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc) for factual aspects. Thank you.