### PR TITLE
Swarm logging content (RHOARDOC-1140)

### DIFF
--- a/docs/topics/con_local-debug-logging.adoc
+++ b/docs/topics/con_local-debug-logging.adoc
@@ -1,0 +1,6 @@
+
+[#local-debug-logging_{context}]
+= Local Debug Logging
+
+To enable debug logging locally, see the xref:enabling-logging_{context}[] section and use the `DEBUG` log level.
+

--- a/docs/topics/proc_accessing-debug-log-output-on-openshift.adoc
+++ b/docs/topics/proc_accessing-debug-log-output-on-openshift.adoc
@@ -5,7 +5,7 @@
 This procedure shows you how to view the debug log output of your Java application running in a container on OpenShift.
 
 .Prerequisites
-* An application with debug logging runnig on OpenShift.
+* An application with debug logging running on OpenShift.
 * The `oc` client authenticated.
 
 .Procedure
@@ -43,6 +43,7 @@ $ oc get pods
 // Add alternative workflow using web console?
 . Follow the console log output for the pod you have just redeployed:
 +
+[source,subs="attributes+"]
 ----
 $ oc logs -f pod/{app-name}-2-aaaaa
 ----
@@ -83,7 +84,7 @@ INFO: Greeting: Hello, Sarah
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc set env dc DC_NAME DEBUG-
+$ oc set env dc/{app-name} JAVA_ENABLE_DEBUG-
 ----
 
 .Related Information

--- a/docs/topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc
@@ -1,0 +1,35 @@
+
+[#enabling-logging_{context}]
+= Enabling logging
+
+Each WildFly Swarm fraction is dependent on the Logging fraction, which means that if you use any WildFly Swarm fraction in your application, logging is automatically enabled on the `INFO` level and higher.
+If you want to enable logging explicitly, add the Logging fraction to the POM file of your application.
+
+.Prerequisites
+
+* A Maven-based application
+
+.Procedure
+
+. Find the `<dependencies>` section in the `pom.xml` file of your application.
+Verify it contains the following coordinates. If it does not, add them.
++
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>logging</artifactId>
+</dependency>
+----
+
+. If you want to log messages of a level other than `INFO`, launch the application while specifying the `swarm.logging` system property:
++
+--
+[source,bash]
+----
+$ mvn swarm:run -Dswarm.logging=FINE
+----
+
+See the link:https://wildfly-swarm.github.io/wildfly-swarm-javadocs/{version}/apidocs/org/wildfly/swarm/config/logging/Level.html[`org.wildfly.swarm.config.logging.Level`] class for the list of available levels.
+--
+

--- a/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc
@@ -1,0 +1,90 @@
+
+[#logging-to-a-file_{context}]
+= Logging to a file
+
+In addition to the console logging, you can save the logs of your application in a file.
+Typically, deployments use rotating logs to save disk space.
+
+In WildFly Swarm, logging is configured using system properties.
+Even though it is possible to use the `-Dproperty=value` syntax when launching your application, it is strongly recommended to configure file logging using the YAML profile files.
+
+.Prerequisites
+
+* A Maven-based application with the logging fraction enabled. For more information, see xref:enabling-logging_{context}[].
+* A writable directory on your file system.
+
+.Procedure
+
+. Open a YAML profile file of your choice.
+If you do not know which one to use, open `project-defaults.yml` in the `src/main/resources` directory in your application sources.
+In the YAML file, add the following section:
++
+[source,yaml]
+----
+swarm:
+  logging:
+----
+. Configure a formatter (optional).
+The following formatters are configured by default:
++
+--
+PATTERN:: Useful for logging into a file.
+COLOR_PATTERN:: Color output. Useful for logging to the console.
+
+To configure a custom formatter, add a new formatter with a pattern of your choice in the `logging` section.
+In this example, it is called `LOG_FORMATTER`:
+
+[source,yaml]
+----
+pattern-formatters:
+  LOG_FORMATTER:
+    pattern: "%p [%c] %s%e%n"
+----
+--
+
+. Configure a file handler to use with the loggers.
+This example shows the configuration of a periodic rotating file handler.
+Under `logging`, add a `periodic-rotating-file-handlers` section with a new handler.
++
+--
+[source,yaml]
+----
+periodic-rotating-file-handlers:
+  FILE:
+    file:
+      path: target/MY_APP_NAME.log
+    suffix: .yyyy-MM-dd
+    named-formatter: LOG_FORMATTER
+    level: INFO
+----
+
+Here, a new handler named `FILE` is created, logging events of the `INFO` level and higher.
+It logs in the `target` directory, and each log file is named `MY_APP_NAME.log` with the suffix `.yyyy-MM-dd`.
+WildFly Swarm automatically parses the log rotation period from the suffix, so ensure you use a format compatible with the `java.text.SimpleDateFormat` class.
+--
+
+. Configure the root logger.
++
+--
+The root logger is by default configured to use the `CONSOLE` handler only.
+Under `logging`, add a `root-logger` section with the handlers you wish to use:
+
+[source,yaml]
+----
+root-logger:
+  handlers:
+  - CONSOLE
+  - FILE
+----
+
+Here, the `FILE` handler from the previous step is used, along with the default console handler.
+--
+
+Below, you can see the complete logging configuration section:
+
+.The logging section in a YAML configuration profile
+[source,yaml]
+----
+include::src/main/resources/profile.yaml[]
+----
+

--- a/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/src/main/resources/profile.yaml
+++ b/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/src/main/resources/profile.yaml
@@ -1,0 +1,15 @@
+swarm:
+  logging:
+    pattern-formatters:
+      LOG_FORMATTER:
+        pattern: "CUSTOM LOG FORMAT %p [%c] %s%e%n"
+    periodic-rotating-file-handlers:
+      FILE:
+        file:
+          path: path/to/your/file.log
+        suffix: .yyyy-MM-dd
+        named-formatter: LOG_FORMATTER
+    root-logger:
+      handlers:
+      - CONSOLE
+      - FILE

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -296,6 +296,10 @@ include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[levelof
 
 include::topics/con_local-debug-logging.adoc[leveloffset=+3]
 
+:context: wf-swarm
+include::topics/proc_accessing-debug-log-output-on-openshift.adoc[leveloffset=+3]
+:context!:
+
 == Monitoring
 
 This section contains information about monitoring your {WildFlySwarm}&ndash;based application running on OpenShift.

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -19,73 +19,6 @@ include::topics/wf-swarm-runtime-overview.adoc[leveloffset=+1]
 
 include::topics/runtime-info-product-version.adoc[leveloffset=+1]
 
-== Building your application
-
-This sections contains information about configuring the {WildFlySwarm} runtime.
-
-include::topics/wildfly-swarm/docs/reference/maven-plugin.adoc[leveloffset=+2]
-
-include::topics/wildfly-swarm/docs/concepts/fractions.adoc[leveloffset=+2]
-include::topics/wildfly-swarm/docs/howto/autodetect-fractions/index.adoc[leveloffset=+3]
-include::topics/wildfly-swarm/docs/howto/explicit-fractions/index.adoc[leveloffset=+3]
-
-:version: {WildFlySwarmProductVersion}
-include::topics/wildfly-swarm/docs/howto/use-a-bom/index.adoc[leveloffset=+2]
-
-=== Logging
-
-include::topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc[leveloffset=+3]
-include::topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc[leveloffset=+3]
-:version!:
-
-include::topics/wildfly-swarm/docs/reference/configuration.adoc[leveloffset=+2]
-
-== Packaging your application
-
-This sections contains information about packaging your {WildFlySwarm}&#x2013;based application for deployment and execution.
-
-include::topics/wildfly-swarm/docs/concepts/packaging-types.adoc[leveloffset=+2]
-include::topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc[leveloffset=+2]
-
-== Testing
-
-include::topics/wildfly-swarm/docs/howto/test-in-container/index.adoc[leveloffset=+2]
-
-== Debugging
-
-This sections contains information about debugging your {WildFlySwarm}&#x2013;based application both in local and remote deployments.
-
-=== Remote Debugging
-:context:
-
-To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
-
-:parameter-debug-property: swarm.debug.port
-:parameter-maven-goal: wildfly-swarm:run
-include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[leveloffset=+3]
-:parameter-debug-property!:
-:parameter-maven-goal!:
-
-:parameter-uberjar-documented:
-include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
-:parameter-uberjar-documented!:
-
-include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
-
-include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]
-
-=== Debug Logging
-
-include::topics/con_local-debug-logging.adoc[leveloffset=+3]
-
-== Monitoring
-
-This section contains information about monitoring your {WildFlySwarm}&ndash;based application running on OpenShift.
-
-=== Accessing JVM metrics for your application on OpenShift
-
-include::topics/proc_accessing-jolokia-using-hawtio-on-openshift.adoc[leveloffset=+3]
-
 // MISSIONS
 include::topics/dev-guide-mission-intro.adoc[leveloffset=+1]
 
@@ -312,6 +245,65 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 //Minimum Viable App
 //Add-ons
 //Building your app
+
+== Building your application
+
+This sections contains information about configuring the {WildFlySwarm} runtime.
+
+include::topics/wildfly-swarm/docs/reference/maven-plugin.adoc[leveloffset=+2]
+
+include::topics/wildfly-swarm/docs/concepts/fractions.adoc[leveloffset=+2]
+include::topics/wildfly-swarm/docs/howto/autodetect-fractions/index.adoc[leveloffset=+3]
+include::topics/wildfly-swarm/docs/howto/explicit-fractions/index.adoc[leveloffset=+3]
+
+:version: {WildFlySwarmProductVersion}
+include::topics/wildfly-swarm/docs/howto/use-a-bom/index.adoc[leveloffset=+2]
+
+=== Logging
+
+include::topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc[leveloffset=+3]
+include::topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc[leveloffset=+3]
+:version!:
+
+include::topics/wildfly-swarm/docs/reference/configuration.adoc[leveloffset=+2]
+
+== Packaging your application
+
+This sections contains information about packaging your {WildFlySwarm}&ndash;based application for deployment and execution.
+
+include::topics/wildfly-swarm/docs/concepts/packaging-types.adoc[leveloffset=+2]
+include::topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc[leveloffset=+2]
+
+== Debugging
+
+This sections contains information about debugging your {WildFlySwarm}&ndash;based application both in local and remote deployments.
+
+=== Remote Debugging
+
+To remotely debug an application, you must first configure it to start in a debugging mode, and then attach a debugger to it.
+
+include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[leveloffset=+3]
+
+:parameter-uberjar-documented:
+include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
+:parameter-uberjar-documented!:
+
+include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
+
+include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]
+
+=== Debug Logging
+
+include::topics/con_local-debug-logging.adoc[leveloffset=+3]
+
+== Monitoring
+
+This section contains information about monitoring your {WildFlySwarm}&ndash;based application running on OpenShift.
+
+=== Accessing JVM metrics for your application on OpenShift
+
+include::topics/proc_accessing-jolokia-using-hawtio-on-openshift.adoc[leveloffset=+3]
+
 
 [appendix]
 include::topics/appendix-s2i-build-process.adoc[leveloffset=+1]

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -31,6 +31,11 @@ include::topics/wildfly-swarm/docs/howto/explicit-fractions/index.adoc[leveloffs
 
 :version: {WildFlySwarmProductVersion}
 include::topics/wildfly-swarm/docs/howto/use-a-bom/index.adoc[leveloffset=+2]
+
+=== Logging
+
+include::topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc[leveloffset=+3]
+include::topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc[leveloffset=+3]
 :version!:
 
 include::topics/wildfly-swarm/docs/reference/configuration.adoc[leveloffset=+2]
@@ -68,6 +73,10 @@ include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
 include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
 
 include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]
+
+=== Debug Logging
+
+include::topics/con_local-debug-logging.adoc[leveloffset=+3]
 
 == Monitoring
 


### PR DESCRIPTION
New content:

_Taken from WFS upstream:_

* General logging information
* Logging into file

_Downstream-only content:_

* Local debug logging
* Debug logging on OpenShift (TBD)

Notes:

* A few issues fixed in the OpenShift content.
* The same workaround used with the `{context}` attribute around the OpenShift section as in #1018.

Resolves [RHOARDOC-1140](https://issues.jboss.org/browse/RHOARDOC-1140).