### PR TITLE
En dash usage (RHOARDOC-1177)

### DIFF
--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -203,7 +203,7 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 
 
 == Debugging
-This section contains information about debugging your {NodeJS}&#x2013;based application and using debug logging in both local and remote deployments.
+This section contains information about debugging your {NodeJS}{ndash}based application and using debug logging in both local and remote deployments.
 
 
 [#remote-debugging]

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -245,7 +245,7 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 
 == Debugging
 
-This sections contains information about debugging your {SpringBoot}&#x2013;based application both in local and remote deployments.
+This sections contains information about debugging your {SpringBoot}{ndash}based application both in local and remote deployments.
 
 === Remote Debugging
 :context: remote-debugging
@@ -273,7 +273,7 @@ include::topics/proc_accessing-debug-logs-on-openshift.adoc[leveloffset=+3]
 
 == Monitoring
 
-This section contains information about monitoring your {SpringBoot}&#x2013;based application running on OpenShift.
+This section contains information about monitoring your {SpringBoot}{ndash}based application running on OpenShift.
 
 === Accessing JVM metrics for your application on OpenShift
 

--- a/docs/topics/contributing-writing-new-content.adoc
+++ b/docs/topics/contributing-writing-new-content.adoc
@@ -13,4 +13,17 @@ link:https://redhat-documentation.github.io/asciidoc-markup-conventions/[Red Hat
 
 link:https://mojo.redhat.com/groups/minimalism-quality-initiative[Minimalism in Red Hat Documentation]:: A Red Hat internal document about applying minimalism to documentation.
 
+[#writing-rules-specific-to-this-repository]
+== Writing Rules Specific to This Repository
+
+When writing new content, adhere to the following rules:
+
+* When using the link:https://en.wikipedia.org/wiki/Dash#En_dash[en dash], use the `\{ndash\}` attribute.
++
+--
+Do *not* use:
+
+* `&amp;ndash;` because it breaks validation.
+* `&amp;#x2013;` even though `\{ndash\}` is currently set to it, because the attribute can change in the future.
+--
 

--- a/docs/topics/proc_debug-start-native-debug-nodejs.adoc
+++ b/docs/topics/proc_debug-start-native-debug-nodejs.adoc
@@ -1,5 +1,5 @@
 = Starting your Application Locally and Attaching the Native Debugger
-The native debugger enables you to debug your {NodeJS}&#x2013;based application using the built-in debugging client.
+The native debugger enables you to debug your {NodeJS}{ndash}based application using the built-in debugging client.
 
 .Prerequisites 
 * An application you want to debug.

--- a/docs/topics/proc_debug-start-v8-debug-nodejs.adoc
+++ b/docs/topics/proc_debug-start-v8-debug-nodejs.adoc
@@ -1,5 +1,5 @@
 = Starting your Application Locally and Attaching the V8 Inspector
-The V8 inspector enables you to debug your {NodeJS}&#x2013;based application using other tools, such as link:https://developers.google.com/web/tools/chrome-devtools/[Chrome DevTools], that use the link:https://chromedevtools.github.io/debugger-protocol-viewer/1-2/[Chrome Debugging Protocol].
+The V8 inspector enables you to debug your {NodeJS}{ndash}based application using other tools, such as link:https://developers.google.com/web/tools/chrome-devtools/[Chrome DevTools], that use the link:https://chromedevtools.github.io/debugger-protocol-viewer/1-2/[Chrome Debugging Protocol].
 
 .Prerequisites 
 * An application you want to debug.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -8,6 +8,8 @@
 
 :imagesdir: images
 
+:ndash: &#x2013;
+
 //uncomment to add styles
 :stylesdir: topics/styles
 //:stylesheet: style.css

--- a/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
@@ -4,7 +4,7 @@
 Using Arquillian, you have the capability of injecting unit tests into a
 running application. This allows you to verify your application is behaving
 correctly. There is an adapter for WildFly Swarm that makes Arquillian-based
-testing work well with WildFly Swarm&#x2013;based applications.
+testing work well with WildFly Swarm{ndash}based applications.
 
 .Prerequisites
 

--- a/docs/topics/wildfly-swarm/docs/reference/maven-plugin.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/maven-plugin.adoc
@@ -35,7 +35,7 @@ Executes your application in the Maven process. The application is stopped if th
 [#maven-plugin-multistart-goal]
 start and multistart::
 Executes your application in a forked process. Generally, it is only useful for running integration tests using a plugin, such as the `maven-failsafe-plugin`.
-The `multistart` variant allows starting multiple WildFly Swarm&#x2013;built applications using Maven GAVs to support complex testing scenarios.
+The `multistart` variant allows starting multiple WildFly Swarm{ndash}built applications using Maven GAVs to support complex testing scenarios.
 
 stop::
 Stops any previously started applications.
@@ -303,7 +303,7 @@ Properties can be used to configure execution and affect the packaging
 or running of your application.
 
 If you add a `<properties>` or `<propertiesFile>` section to the `<configuration>` of the plugin, the properties are used when executing your application using the `mvn wildfly-swarm:run` command.
-In addition to that, the same properties are added to your `MYAPP-swarm.jar` file to affect subsequent executions of the uberjar.
+In addition to that, the same properties are added to your `_myapp_-swarm.jar` file to affect subsequent executions of the uberjar.
 Any properties loaded from the `<propertiesFile>` override identically-named properties in the `<properties>` section.
 
 Any properties added to the uberjar can be overridden at runtime using the traditional `-Dname=value` mechanism of the `java` binary, or using the YAML-based configuration files.

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -260,7 +260,7 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 
 == Debugging
 
-This sections contains information about debugging your {VertX}&#x2013;based application both in local and remote deployments.
+This sections contains information about debugging your {VertX}{ndash}based application both in local and remote deployments.
 
 === Remote Debugging
 :context:
@@ -307,7 +307,7 @@ include::topics/proc_accessing-debug-logs-on-openshift.adoc[leveloffset=+3]
 
 == Monitoring
 
-This section contains information about monitoring your {VertX}&#x2013;based application running on OpenShift.
+This section contains information about monitoring your {VertX}{ndash}based application running on OpenShift.
 
 === Accessing JVM metrics for your application on OpenShift
 

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -270,7 +270,7 @@ include::topics/wildfly-swarm/docs/reference/configuration.adoc[leveloffset=+2]
 
 == Packaging your application
 
-This sections contains information about packaging your {WildFlySwarm}&#x2013;based application for deployment and execution.
+This sections contains information about packaging your {WildFlySwarm}{ndash}based application for deployment and execution.
 
 include::topics/wildfly-swarm/docs/concepts/packaging-types.adoc[leveloffset=+2]
 include::topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc[leveloffset=+2]
@@ -281,7 +281,7 @@ include::topics/wildfly-swarm/docs/howto/test-in-container/index.adoc[leveloffse
 
 == Debugging
 
-This sections contains information about debugging your {WildFlySwarm}&#x2013;based application both in local and remote deployments.
+This sections contains information about debugging your {WildFlySwarm}{ndash}based application both in local and remote deployments.
 
 === Remote Debugging
 
@@ -311,7 +311,7 @@ include::topics/proc_accessing-debug-logs-on-openshift.adoc[leveloffset=+3]
 
 == Monitoring
 
-This section contains information about monitoring your {WildFlySwarm}&#x2013;based application running on OpenShift.
+This section contains information about monitoring your {WildFlySwarm}{ndash}based application running on OpenShift.
 
 === Accessing JVM metrics for your application on OpenShift
 


### PR DESCRIPTION
**NOTE** Waiting for upstream WFS to accept the changes and sync them to the prod repo.

Changes:

* All explicit usage of `&#x2013;` is replaced with `{ndash}`, which is set to that value.
* Incorporates changes committed to the WFS upstream.
* Above practice is documented in the Contribution Guide.

Resolves RHOARDOC-1177.