### PR TITLE
fixes RHOARDOC-1227

### DIFF
--- a/docs/topics/readme/cd-circuit-breaker-spring-boot.properties
+++ b/docs/topics/readme/cd-circuit-breaker-spring-boot.properties
@@ -5,5 +5,6 @@ fileLocation=src/main/resources/static/index.html
 greeting-app-name=springboot-cb-greeting
 name-app-name=springboot-cb-name
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-circuit-breaker-vert.x.properties
+++ b/docs/topics/readme/cd-circuit-breaker-vert.x.properties
@@ -5,5 +5,6 @@ fileLocation=src/main/resources/webroot/index.html
 greeting-app-name=greeting-service
 name-app-name=name-service
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-circuit-breaker-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-circuit-breaker-wildfly-swarm.properties
@@ -5,5 +5,6 @@ fileLocation=src/main/webapp/index.html
 greeting-app-name=greeting-service
 name-app-name=name-service
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-configmap-nodejs.properties
+++ b/docs/topics/readme/cd-configmap-nodejs.properties
@@ -8,5 +8,4 @@ configmapFileName=app-config.yml
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
-
-
+integrationTestSection=

--- a/docs/topics/readme/cd-configmap-spring-boot.properties
+++ b/docs/topics/readme/cd-configmap-spring-boot.properties
@@ -6,5 +6,6 @@ OSOConfigMap=
 app-name=booster-configmap-spring-boot
 configmapFileName=src/main/etc/application.properties
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-configmap-vert.x.properties
+++ b/docs/topics/readme/cd-configmap-vert.x.properties
@@ -6,5 +6,6 @@ OSOConfigMap=oc create configmap app-config --from-file=app-config.yml
 app-name=booster-configmap-vertx
 configmapFileName=app-config.yml
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-configmap-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-configmap-wildfly-swarm.properties
@@ -6,5 +6,6 @@ OSOConfigMap=$ oc create configmap app-config --from-file=app-config.yml
 app-name=booster-configmap-wildfly-swarm
 configmapFileName=app-config.yml
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-crud-nodejs.properties
+++ b/docs/topics/readme/cd-crud-nodejs.properties
@@ -4,3 +4,4 @@ guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
 cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/cd-crud-spring-boot.properties
+++ b/docs/topics/readme/cd-crud-spring-boot.properties
@@ -2,5 +2,6 @@ localRunCMD=mvn spring-boot:run
 OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-crud-vert.x.properties
+++ b/docs/topics/readme/cd-crud-vert.x.properties
@@ -2,5 +2,6 @@ localRunCMD=mvn compile vertx:run
 OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-crud-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-crud-wildfly-swarm.properties
@@ -2,5 +2,6 @@ localRunCMD=mvn wildfly-swarm:run
 OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-health-check-nodejs.properties
+++ b/docs/topics/readme/cd-health-check-nodejs.properties
@@ -6,3 +6,4 @@ app-name=booster-health-check-nodejs
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/cd-health-check-spring-boot.properties
+++ b/docs/topics/readme/cd-health-check-spring-boot.properties
@@ -4,5 +4,6 @@ guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
 app-name=booster-health-check-spr
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-health-check-vert.x.properties
+++ b/docs/topics/readme/cd-health-check-vert.x.properties
@@ -4,5 +4,6 @@ guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
 app-name=booster-health-check-ver
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-health-check-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-health-check-wildfly-swarm.properties
@@ -4,5 +4,6 @@ guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
 app-name=booster-health-check-wildfly-swarm
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-rest-http-nodejs.properties
+++ b/docs/topics/readme/cd-rest-http-nodejs.properties
@@ -5,3 +5,4 @@ fileLocation=public/index.html
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/cd-rest-http-secured-nodejs.properties
+++ b/docs/topics/readme/cd-rest-http-secured-nodejs.properties
@@ -3,3 +3,4 @@ app-name=nodejs
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository} 
 guideURL=https://appdev.openshift.io/docs/nodejs-runtime.html
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/cd-rest-http-secured-spring-boot.properties
+++ b/docs/topics/readme/cd-rest-http-secured-spring-boot.properties
@@ -3,3 +3,4 @@ app-name=sb
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/spring-boot-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/cd-rest-http-secured-vert.x.properties
+++ b/docs/topics/readme/cd-rest-http-secured-vert.x.properties
@@ -3,3 +3,4 @@ app-name=vx
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/vertx-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/cd-rest-http-secured-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-rest-http-secured-wildfly-swarm.properties
@@ -1,5 +1,6 @@
 localRunCMD=mvn clean fabric8:deploy -Popenshift -DskipTests -DSSO_AUTH_SERVER_URL=$(oc get route secure-sso -o jsonpath='{"https://"}{.spec.host}{"/auth\n"}')
 app-name=wf
-gitCMD=git clone git@github.com:${loggedUser}/${targetRepository} 
+gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/wf-swarm-runtime.html#running-the-secured-booster-integration-tests[Secured Booster documentation].

--- a/docs/topics/readme/cd-rest-http-spring-boot.properties
+++ b/docs/topics/readme/cd-rest-http-spring-boot.properties
@@ -3,5 +3,6 @@ OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-rest-http-vert.x.properties
+++ b/docs/topics/readme/cd-rest-http-vert.x.properties
@@ -3,5 +3,6 @@ OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/cd-rest-http-wildfly-swarm.properties
+++ b/docs/topics/readme/cd-rest-http-wildfly-swarm.properties
@@ -3,5 +3,6 @@ OSORunCMD=mvn clean fabric8:deploy -Popenshift
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
-cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console. 
+cicdSection=IMPORTANT: As part of the process of creating this booster, developers.redhat.com/launch or the Fabric8 Launcher tool set up a project with a CI/CD deployment of this booster. You can see the status of this deployment in your Single-node OpenShift Cluster or OpenShift Online Web Console.
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/circuit-breaker-README.adoc
+++ b/docs/topics/readme/circuit-breaker-README.adoc
@@ -26,6 +26,7 @@ $ oc new-project MY_PROJECT_NAME
 $ ${OSORunCMD}
 ----
 
+${integrationTestSection}
 
 == Interacting with the Booster on a Single-node OpenShift Cluster
 

--- a/docs/topics/readme/configmap-README.adoc
+++ b/docs/topics/readme/configmap-README.adoc
@@ -67,7 +67,7 @@ $ oc create configmap app-config --from-file=${configmapFileName}
 $ ${OSORunCMD}
 ----
 
-
+${integrationTestSection}
 
 == Interacting with the Booster on a Single-node OpenShift Cluster
 

--- a/docs/topics/readme/crud-README.adoc
+++ b/docs/topics/readme/crud-README.adoc
@@ -102,6 +102,7 @@ curl -X DELETE http://MY_APP_NAME-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/f
 
 NOTE: If you receive an HTTP Error code `503` as a response after executing these commands, it means that the application is not ready yet.
 
+${integrationTestSection}
 
 == More Information
 You can learn more about this booster and rest of the ${runtime} runtime in the link:${guideURL}[${runtime} Runtime Guide].

--- a/docs/topics/readme/health-check-README.adoc
+++ b/docs/topics/readme/health-check-README.adoc
@@ -18,6 +18,8 @@ $ cd ${targetRepository}
 $ ${localRunCMD}
 ----
 
+${integrationTestSection}
+
 == Interacting with the Booster Locally
 To interact with your booster while its running, use the form at `http://localhost:8080` or the `curl` command:
 

--- a/docs/topics/readme/osio-circuit-breaker-spring-boot.properties
+++ b/docs/topics/readme/osio-circuit-breaker-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-circuit-breaker-vert.x.properties
+++ b/docs/topics/readme/osio-circuit-breaker-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-circuit-breaker-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-circuit-breaker-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-configmap-nodejs.properties
+++ b/docs/topics/readme/osio-configmap-nodejs.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
+integrationTestSection=

--- a/docs/topics/readme/osio-configmap-spring-boot.properties
+++ b/docs/topics/readme/osio-configmap-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-configmap-vert.x.properties
+++ b/docs/topics/readme/osio-configmap-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-configmap-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-configmap-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-crud-nodejs.properties
+++ b/docs/topics/readme/osio-crud-nodejs.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
+integrationTestSection=

--- a/docs/topics/readme/osio-crud-spring-boot.properties
+++ b/docs/topics/readme/osio-crud-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-crud-vert.x.properties
+++ b/docs/topics/readme/osio-crud-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-crud-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-crud-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-health-check-nodejs.properties
+++ b/docs/topics/readme/osio-health-check-nodejs.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
+integrationTestSection=

--- a/docs/topics/readme/osio-health-check-spring-boot.properties
+++ b/docs/topics/readme/osio-health-check-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-health-check-vert.x.properties
+++ b/docs/topics/readme/osio-health-check-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-health-check-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-health-check-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-rest-http-nodejs.properties
+++ b/docs/topics/readme/osio-rest-http-nodejs.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
+integrationTestSection=

--- a/docs/topics/readme/osio-rest-http-secured-nodejs.properties
+++ b/docs/topics/readme/osio-rest-http-secured-nodejs.properties
@@ -1,2 +1,3 @@
 guideURL=https://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=

--- a/docs/topics/readme/osio-rest-http-secured-spring-boot.properties
+++ b/docs/topics/readme/osio-rest-http-secured-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/spring-boot-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/osio-rest-http-secured-vert.x.properties
+++ b/docs/topics/readme/osio-rest-http-secured-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/vertx-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/osio-rest-http-secured-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-rest-http-secured-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/wf-swarm-runtime.html#running-the-secured-booster-integration-tests[Secured Booster documentation].

--- a/docs/topics/readme/osio-rest-http-spring-boot.properties
+++ b/docs/topics/readme/osio-rest-http-spring-boot.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-rest-http-vert.x.properties
+++ b/docs/topics/readme/osio-rest-http-vert.x.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/osio-rest-http-wildfly-swarm.properties
+++ b/docs/topics/readme/osio-rest-http-wildfly-swarm.properties
@@ -1,2 +1,3 @@
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/rest-http-README.adoc
+++ b/docs/topics/readme/rest-http-README.adoc
@@ -37,7 +37,7 @@ To update your booster:
 . Stop your booster.
 +
 NOTE: To stop your running booster in a Linux or macOS terminal, use `CTRL+C`. In a Windows command prompt, you can use `CTRL + Break(pause)`.
- 
+
 . Make your change (e.g. edit `${fileLocation}`).
 . Restart your booster.
 . Confirm your change appears.
@@ -55,6 +55,8 @@ $ oc new-project MY_PROJECT_NAME
 
 $ ${OSORunCMD}
 ----
+
+${integrationTestSection}
 
 == More Information
 You can learn more about this booster and rest of the ${runtime} runtime in the link:${guideURL}[${runtime} Runtime Guide].

--- a/docs/topics/readme/rest-http-secured-README.adoc
+++ b/docs/topics/readme/rest-http-secured-README.adoc
@@ -26,6 +26,7 @@ $ oc create -f service.sso.yaml
 $ ${localRunCMD}
 ----
 
+${integrationTestSection}
 
 == Interacting with the Booster on a Single-node OpenShift Cluster
 

--- a/docs/topics/readme/zip-circuit-breaker-spring-boot.properties
+++ b/docs/topics/readme/zip-circuit-breaker-spring-boot.properties
@@ -8,3 +8,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-circuit-breaker-vert.x.properties
+++ b/docs/topics/readme/zip-circuit-breaker-vert.x.properties
@@ -8,3 +8,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-circuit-breaker-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-circuit-breaker-wildfly-swarm.properties
@@ -8,3 +8,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-configmap-nodejs.properties
+++ b/docs/topics/readme/zip-configmap-nodejs.properties
@@ -9,7 +9,4 @@ gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
-
-
-
-
+integrationTestSection=

--- a/docs/topics/readme/zip-configmap-spring-boot.properties
+++ b/docs/topics/readme/zip-configmap-spring-boot.properties
@@ -9,3 +9,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-configmap-vert.x.properties
+++ b/docs/topics/readme/zip-configmap-vert.x.properties
@@ -9,3 +9,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-configmap-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-configmap-wildfly-swarm.properties
@@ -9,3 +9,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-crud-nodejs.properties
+++ b/docs/topics/readme/zip-crud-nodejs.properties
@@ -4,3 +4,4 @@ guideURL=http://appdev.openshift.io/docs/nodejs-runtime.html
 fileLocation=public/index.html
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/zip-crud-spring-boot.properties
+++ b/docs/topics/readme/zip-crud-spring-boot.properties
@@ -4,3 +4,4 @@ guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 fileLocation=src/main/resources/static/index.html
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-crud-vert.x.properties
+++ b/docs/topics/readme/zip-crud-vert.x.properties
@@ -4,3 +4,4 @@ guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 fileLocation=src/main/resources/webroot/index.html
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-crud-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-crud-wildfly-swarm.properties
@@ -4,3 +4,4 @@ guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 fileLocation=src/main/webapp/index.html
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-health-check-nodejs.properties
+++ b/docs/topics/readme/zip-health-check-nodejs.properties
@@ -7,3 +7,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/zip-health-check-spring-boot.properties
+++ b/docs/topics/readme/zip-health-check-spring-boot.properties
@@ -7,3 +7,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-health-check-vert.x.properties
+++ b/docs/topics/readme/zip-health-check-vert.x.properties
@@ -7,3 +7,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-health-check-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-health-check-wildfly-swarm.properties
@@ -7,3 +7,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-rest-http-nodejs.properties
+++ b/docs/topics/readme/zip-rest-http-nodejs.properties
@@ -6,3 +6,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/zip-rest-http-secured-nodejs.properties
+++ b/docs/topics/readme/zip-rest-http-secured-nodejs.properties
@@ -3,3 +3,4 @@ app-name=nodejs
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository} 
 guideURL=https://appdev.openshift.io/docs/nodejs-runtime.html
 prerequisite=IMPORTANT: This booster requires Node.js 8.x or greater and `npm` 5 or greater.
+integrationTestSection=

--- a/docs/topics/readme/zip-rest-http-secured-spring-boot.properties
+++ b/docs/topics/readme/zip-rest-http-secured-spring-boot.properties
@@ -3,3 +3,4 @@ app-name=sb
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/spring-boot-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/spring-boot-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/zip-rest-http-secured-vert.x.properties
+++ b/docs/topics/readme/zip-rest-http-secured-vert.x.properties
@@ -3,3 +3,4 @@ app-name=vx
 gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/vertx-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/vertx-runtime.html#running-the-secured-booster-integration-tests_context[Secured Booster documentation].

--- a/docs/topics/readme/zip-rest-http-secured-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-rest-http-secured-wildfly-swarm.properties
@@ -1,5 +1,6 @@
 localRunCMD=mvn clean fabric8:deploy -Popenshift -DskipTests -DSSO_AUTH_SERVER_URL=$(oc get route secure-sso -o jsonpath='{"https://"}{.spec.host}{"/auth\n"}')
 app-name=wf
-gitCMD=git clone git@github.com:${loggedUser}/${targetRepository} 
+gitCMD=git clone git@github.com:${loggedUser}/${targetRepository}
 guideURL=http://appdev.openshift.io/docs/wf-swarm-runtime.html
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=To run the integration test on the Secured HTTP API booster follow the steps in the link:https://appdev.openshift.io/docs/wf-swarm-runtime.html#running-the-secured-booster-integration-tests[Secured Booster documentation].

--- a/docs/topics/readme/zip-rest-http-spring-boot.properties
+++ b/docs/topics/readme/zip-rest-http-spring-boot.properties
@@ -6,3 +6,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-rest-http-vert.x.properties
+++ b/docs/topics/readme/zip-rest-http-vert.x.properties
@@ -6,3 +6,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x or greater.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.

--- a/docs/topics/readme/zip-rest-http-wildfly-swarm.properties
+++ b/docs/topics/readme/zip-rest-http-wildfly-swarm.properties
@@ -6,3 +6,4 @@ gitCMD=unzip ${artifactId}.zip
 targetRepository=${artifactId}
 cicdSection=
 prerequisite=IMPORTANT: This booster requires Java 8 JDK or greater and Maven 3.3.x.
+integrationTestSection=NOTE: Run the set of integration tests included with this booster using `mvn clean verify -Popenshift,openshift-it`.


### PR DESCRIPTION
@rhoads-zach I've added the `integrationTestSection` variable containing a `NOTE: ` to the launcher generated `README.adoc` files. The note contains the command to run the integration tests (for boosters that contain them).
NOTE: I have not yet done so for the `osio-*-README.adoc`, but will do so, if we agree to apply this change.

The idea behind this is that if we include the test instructions in the README, users won't have to look at the detailed docs when getting started with the booster.

I haven't been able to apply formatting to  a section stored inside a variable (`\n` does not work for line breaks), so this solution circumvents the need for formatting by keeping the minimum instructions inside a `NOTE` admonition block. (Admittedly not the squeaky-cleanest way of doing so, but IMHO gets the point across)

@rhoads-zach @tradej Please let me know what you think.