### PR TITLE
fixes RHOARDOC-1239

### DIFF
--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -242,18 +242,13 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 == Application Development
 The recommended approach for specifying and using supported and tested maven artifacts in a {SpringBoot} application is to use the OpenShift Application Runtimes {SpringBoot} BOM.
 
+//creating an app from scratch
 // workaround to resolve ID conflicts:
 :context: spring-boot
-//creating an app from scratch
-include::topics/assembly_creating-a-basic-spring-boot-application.adoc[leveloffset=+2]
-
-:parameter-maven-command: $ mvn spring-boot:run
-:parameter-runtime-name: {SpringBoot}
 :parameter-runtime: spring-boot
+include::topics/assembly_creating-a-basic-spring-boot-application.adoc[leveloffset=+2]
 include::topics/proc_deploying-an-existing-application-to-openshift.adoc[leveloffset=+2]
 :parameter-runtime!:
-:parameter-runtime-name!:
-:parameter-maven-command!:
 :!context:
 
 == Debugging

--- a/docs/topics/assembly_creating-a-basic-spring-boot-application.adoc
+++ b/docs/topics/assembly_creating-a-basic-spring-boot-application.adoc
@@ -4,13 +4,14 @@
 
 In addition to xref:mission-rest-http-spring-boot[using a booster], you can create new {runtime} applications from scratch and deploy them to OpenShift.
 
+:parameter-runtime: spring-boot
 :parameter-maven-command: $ mvn spring-boot:run
 :parameter-response: {"content":"Greetings!"}
 :parameter-url: http://{app-name}-{project-name}.{os-route-hostname}
 include::proc_creating-an-application.adoc[leveloffset=+1]
 
 include::proc_deploying-an-application-to-openshift.adoc[leveloffset=+1]
-:parameter-maven-command!:
+:parameter-maven-command:
 :parameter-response:
 :parameter-url:
-
+:parameter-runtime:

--- a/docs/topics/assembly_creating-a-basic-vertx-application.adoc
+++ b/docs/topics/assembly_creating-a-basic-vertx-application.adoc
@@ -4,13 +4,14 @@
 
 In addition to xref:mission-rest-http-vertx[using a booster], you can create new {runtime} applications from scratch and deploy them to OpenShift.
 
+:parameter-runtime: vertx
 :parameter-maven-command: $ mvn vertx:run
-:parameter-response: {"content":"Greetings!"}
+:parameter-response: Greetings!
 :parameter-url: http://{app-name}-{project-name}.{os-route-hostname}
 include::proc_creating-an-application.adoc[leveloffset=+1]
 
 include::proc_deploying-an-application-to-openshift.adoc[leveloffset=+1]
-:parameter-maven-command!:
-:parameter-response:
 :parameter-url:
-
+:parameter-response:
+:parameter-maven-command:
+:parameter-runtime:

--- a/docs/topics/proc_creating-an-application.adoc
+++ b/docs/topics/proc_creating-an-application.adoc
@@ -2,6 +2,8 @@
 //
 //  context: used in anchor IDs to conflicts due to duplicate IDs.
 //  parameter-maven-command: This is used to substitute the Maven command appropriate to the runtime being used.
+//  parameter-response: The expected response provided by the Java application. Can either be formatted as plain text or a JSON object.
+//  parameter-runtime: Ensures that xrefs link to boosters for the appropriate runtime.
 //
 // Rationale: This procedure is the same for 2 or more runtimes.
 
@@ -78,5 +80,10 @@ endif::[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ curl http://localhost:8080
-{"content":"Greetings!"}
+{parameter-response}
 ----
+
+.Additional information
+
+* As a recommended practice, you can configure liveness and readiness probes to enable health monitoring for your application when running on OpenShift.
+To learn how application health monitoring on OpenShift works, try the xref:mission-health-check-{parameter-runtime}[Health Check booster].

--- a/docs/topics/resources/vert-x/vertx-openshift-pom-config-example.xml
+++ b/docs/topics/resources/vert-x/vertx-openshift-pom-config-example.xml
@@ -15,18 +15,6 @@
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <enricher>
-                <excludes>
-                  <exclude>f8-maven-scm</exclude>
-                </excludes>
-                <config>
-                  <vertx-health-check>
-                    <path>/</path>
-                  </vertx-health-check>
-                </config>
-              </enricher>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/docs/topics/resources/vert-x/vertx-starter-example-pom.xml
+++ b/docs/topics/resources/vert-x/vertx-starter-example-pom.xml
@@ -17,6 +17,7 @@
     <vertx.verticle>io.openshift.booster.MyApplication</vertx.verticle>
   </properties>
 
+  <!-- Import dependencies from the RHOAR Vert.x BOM file. -->
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -29,6 +30,7 @@
     </dependencies>
   </dependencyManagement>
 
+  <!-- Specify the RHOAR Vert.x artifacts that your application depends on. -->
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -40,7 +42,7 @@
     </dependency>
   </dependencies>
 
-  <!-- Specify the repositories containing RHOAR artifacts -->
+  <!-- Specify the repositories containing RHOAR artifacts. -->
   <repositories>
     <repository>
       <id>{red-hat-ga-repo-id}</id>
@@ -49,6 +51,7 @@
     </repository>
   </repositories>
 
+  <!-- Specify the repositories containing the plugins used to execute the build of your application. -->
   <pluginRepositories>
     <pluginRepository>
       <id>{red-hat-ga-repo-id}</id>
@@ -57,6 +60,7 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <!-- Configure your application to be packaged using the Vert.x Maven Plugin. -->
   <build>
     <plugins>
       <plugin>
@@ -76,6 +80,7 @@
     </plugins>
   </build>
 
+  <!-- Configure your application to be deployed to OpenShift using the Fabric8 Maven Plugin. -->
   <profiles>
     <profile>
       <id>openshift</id>
@@ -87,25 +92,12 @@
             <version>{Fabric8MavenPluginVersion}</version>
             <executions>
               <execution>
-                <id>fmp</id>
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
                 </goals>
               </execution>
             </executions>
-            <configuration>
-              <enricher>
-                <excludes>
-                  <exclude>f8-maven-scm</exclude>
-                </excludes>
-                <config>
-                  <vertx-health-check>
-                    <path>/</path>
-                  </vertx-health-check>
-                </config>
-              </enricher>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -260,16 +260,12 @@ include::topics/secured-mission-resources.adoc[leveloffset=+3]
 
 // workaround to resolve ID conflicts:
 :context: vert-x
+:parameter-runtime: vertx
 include::topics/assembly_creating-a-basic-vertx-application.adoc[leveloffset=+2]
 
-:parameter-maven-command: $ mvn vertx:run
-:parameter-runtime-name: {VertX}
-:parameter-runtime: vertx
 include::topics/proc_deploying-an-existing-application-to-openshift.adoc[leveloffset=+2]
 :parameter-runtime!:
-:parameter-runtime-name!:
-:parameter-maven-command!:
-:!context:
+:context!:
 
 == Debugging
 


### PR DESCRIPTION
According to information form @cescoffier, the `<exclude>f8-maven-scm</exclude>` is not required and the `<vertx-health-check>` should be replaced by the `<vertx.health>` property. 

@Ladicek Please let me know what you think

Additional actions: Added explanatory comments to the Vert.x POM example.