### PR TITLE
Build on RHEL

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,0 +1,16 @@
+FROM prod.registry.devshift.net/osio-prod/base/openshift-nginx:latest
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV LANG=en_US.utf8
+ENTRYPOINT /usr/bin/entrypoint.sh
+
+USER root
+ADD nginx.conf /etc/nginx/nginx.conf
+
+RUN rm -rf /usr/share/nginx/html
+
+COPY scripts/entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+
+COPY html /usr/share/nginx/html

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,42 +1,51 @@
 #!/usr/bin/env bash
 
+set -x
+
 GENERATOR_DOCKER_HUB_USERNAME=openshiftioadmin
 REGISTRY_URI="push.registry.devshift.net"
 REGISTRY_NS="fabric8"
 REGISTRY_IMAGE="launcher-documentation"
-REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
 BUILDER_IMAGE="launcher-documentation-builder"
 BUILDER_CONT="launcher-documentation-builder-container"
 DEPLOY_IMAGE="launcher-documentation-deploy"
 
+if [ "$TARGET" = "rhel" ]; then
+    REGISTRY_URL=${REGISTRY_URI}/osio-prod/${REGISTRY_NS}/${REGISTRY_IMAGE}
+    DOCKERFILE="Dockerfile.deploy.rhel"
+else
+    REGISTRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+    DOCKERFILE="Dockerfile.deploy"
+fi
+
 TARGET_DIR="html"
 
-function tag_push() {
-    TARGET_IMAGE=$1
-    USERNAME=$2
-    PASSWORD=$3
-    REGISTRY=$4
+function docker_login() {
+    local USERNAME=$1
+    local PASSWORD=$2
+    local REGISTRY=$3
 
-    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
     if [ -n "${USERNAME}" ] && [ -n "${PASSWORD}" ]; then
         docker login -u ${USERNAME} -p ${PASSWORD} ${REGISTRY}
     fi
-    docker push ${TARGET_IMAGE}
+}
 
+function tag_push() {
+    local TARGET_IMAGE=$1
+
+    docker tag ${DEPLOY_IMAGE} ${TARGET_IMAGE}
+    docker push ${TARGET_IMAGE}
 }
 
 # Exit on error
 set -e
 
-if [ -z $CICO_LOCAL ]; then
+if [ -z "$CICO_LOCAL" ]; then
     [ -f jenkins-env ] && cat jenkins-env | grep -e PASS -e GIT -e DEVSHIFT > inherit-env
     [ -f inherit-env ] && . inherit-env
 
     # We need to disable selinux for now, XXX
-    /usr/sbin/setenforce 0
-
-    # Get all the deps in
-    yum -y install docker make git
+    /usr/sbin/setenforce 0 || :
 
     # Get all the deps in
     yum -y install docker make git
@@ -51,9 +60,9 @@ rm -rf ${TARGET_DIR}/
 #BUILD
 docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
 
-mkdir -m 777 ${TARGET_DIR}/
-mkdir -m 777 ${TARGET_DIR}/docs
-mkdir -m 777 ${TARGET_DIR}/docs/images
+mkdir -pm 777 ${TARGET_DIR}/
+mkdir -pm 777 ${TARGET_DIR}/docs
+mkdir -pm 777 ${TARGET_DIR}/docs/images
 
 docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
 
@@ -62,12 +71,16 @@ docker exec ${BUILDER_CONT} sh scripts/build_guides.sh
 #Need to do this again to set permission of images and html files
 chmod -R 0777 ${TARGET_DIR}/
 
+#LOGIN
+docker_login "${DEVSHIFT_USERNAME}" "${DEVSHIFT_PASSWORD}" "${REGISTRY_URI}"
+
 #BUILD DEPLOY IMAGE
-docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
+docker build -t ${DEPLOY_IMAGE} -f "${DOCKERFILE}" .
 
 #PUSH
-if [ -z $CICO_LOCAL ]; then
+if [ -z "$CICO_LOCAL" ]; then
     TAG=$(echo $GIT_COMMIT | cut -c1-${DEVSHIFT_TAG_LEN})
-    tag_push "${REGISTRY_URL}:${TAG}" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
-    tag_push "${REGISTRY_URL}:latest" ${DEVSHIFT_USERNAME} ${DEVSHIFT_PASSWORD} ${REGISTRY_URI}
+    docker_login "${DEVSHIFT_USERNAME}" "${DEVSHIFT_PASSWORD}" "${REGISTRY_URI}"
+    tag_push "${REGISTRY_URL}:${TAG}"
+    tag_push "${REGISTRY_URL}:latest"
 fi


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

- The build scripts will be executed twice on the same machine, once for
  CentOS and one for RHEL
- `docker login` is required to run `docker build`
- The image target is different if TARGET=rhel
- There is a separate Dockerfile for the RHEL build