### PR TITLE
chore: update package.json breakdown to be inline with updated boosters

### DIFF
--- a/docs/topics/http-api-nodejs-package-json.adoc
+++ b/docs/topics/http-api-nodejs-package-json.adoc
@@ -20,13 +20,14 @@
     "release": "standard-version",
     "openshift": "nodeshift --strictSSL=false --nodeVersion=8.x", <2>
     "postinstall": "license-reporter report && license-reporter save --xml licenses.xml",
-    "start": "PORT=8080 node ./bin/www" <3>
+    "start": "node ." <3>
   },
+  "main": "./bin/www", <4>
   "repository": {
     "type": "git",
     "url": "git://github.com/bucharest-gold/nodejs-rest-http.git"
   },
-  "files": [ <4>
+  "files": [ <5>
     "package.json",
     "app.js",
     "public",
@@ -38,16 +39,8 @@
     "url": "https://github.com/bucharest-gold/nodejs-rest-http/issues"
   },
   "homepage": "https://github.com/bucharest-gold/nodejs-rest-http",
-  "devDependencies": { <5>
+  "devDependencies": { <6>
     "coveralls": "^3.0.0",
-    "eslint": "~4.17.0",
-    "eslint-config-semistandard": "~12.0.0",
-    "eslint-config-standard": "~11.0.0-beta.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-node": "^6.0.0",
-    "eslint-plugin-promise": "~3.6.0",
-    "eslint-plugin-react": "~7.6.0",
-    "eslint-plugin-standard": "~3.0.1",
     "nodeshift": "^1.3.0",
     "nsp": "~3.1.0",
     "nyc": "~11.4.1",
@@ -55,9 +48,10 @@
     "supertest": "^3.0.0",
     "szero": "^1.0.0",
     "tap-spec": "~4.1.1",
-    "tape": "~4.8.0"
+    "tape": "~4.8.0",
+    "xo": "~0.20.3"
   },
-  "dependencies": { <6>
+  "dependencies": { <7>
     "body-parser": "^1.18.2",
     "debug": "^3.1.0",
     "express": "^4.16.0",
@@ -69,6 +63,7 @@
 <1> A `npm` script for running unit tests.  Run with `npm run test`.
 <2> A `npm` script for deploying this application to {OpenShiftLocal}.  Run with `npm run openshift`.  The `strictSSL` option allows us to deploy to {OpenShiftLocal} instances with self-signed certificates.
 <3> A `npm` script for starting this application.  Run with `npm start`.
-<4> Specifies the files to be included in the binary that is uploaded to {OpenShiftLocal}.
-<5> A list of development dependencies to be installed from the `npm` registry.  These are used for testing and deployment to {OpenShiftLocal}.
-<6> A list of dependencies to be installed from the `npm` registry.
+<4> The primary entrypoint for the application when run with `npm start`.
+<5> Specifies the files to be included in the binary that is uploaded to {OpenShiftLocal}.
+<6> A list of development dependencies to be installed from the `npm` registry.  These are used for testing and deployment to {OpenShiftLocal}.
+<7> A list of dependencies to be installed from the `npm` registry.


### PR DESCRIPTION
The package.json changed just a little bit, so this reflects those changes

Only affects the community docs atm

launcher PR https://github.com/fabric8-launcher/launcher-booster-catalog/pull/231