### PR TITLE
RHOAR-1228: Sync WFS 7.1 sources

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -89,7 +89,7 @@
 :nodejs-runtime-guide-name: {NodeJS} Runtime Guide
 
 // used in the BOM file example.
-:WildFlySwarmProductVersion: 7.0.1.redhat-20
+:WildFlySwarmProductVersion: 7.1.0.redhat-77
 // also used in pom.xml examples for Spring Boot and Vertx
 :Fabric8MavenPluginVersion: 3.5.38
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -28,6 +28,7 @@
 :CDK: Red Hat Container Development Kit
 :OpenShiftContainerPlatform: OpenShift Container Platform
 :WildFlySwarm: WildFly Swarm
+:Thorntail: WildFly Swarm // Before rename
 :SpringBoot: Spring Boot
 :VertX: Eclipse Vert.x
 :NodeJS: Node.js

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -94,7 +94,7 @@
 :Fabric8MavenPluginVersion: 3.5.38
 
 // used in the links to additional upstream Swarm docs.
-:WildFlySwarmVersion: 2017.10.0
+:WildFlySwarmVersion: 2018.3.3
 
 // spring boot version for rt guide
 :SpringBootVersion: 1.5.10.RELEASE

--- a/docs/topics/wf-swarm-dev-guide-additional-resources.adoc
+++ b/docs/topics/wf-swarm-dev-guide-additional-resources.adoc
@@ -1,9 +1,7 @@
 [[wf-swarm-additional-resources]]
 = Additional Resources
 
-* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-howto/v/{WildFlySwarmVersion}/[{WildFlySwarm} HowTo Guide]
-* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-reference-guide/v/{WildFlySwarmVersion}/[{WildFlySwarm} Reference]
-* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/v/{WildFlySwarmVersion}/[{WildFlySwarm} User Guide]
+* link:https://docs.wildfly-swarm.io/{WildFlySwarmVersion}/[{WildFlySwarm} Community Documentation]
 * link:https://github.com/wildfly-swarm/wildfly-swarm-presentations[{WildFlySwarm} Presentations]
 * link:https://github.com/redhat-Microservices/lab_swarm-openshift[{WildFlySwarm}, Microservices & OpenShift Lab]
 * link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/wildfly_swarm_microservices_on_red_hat_openshift_container_platform_3/[{WildFlySwarm} Microservices On Red Hat OpenShift Container Platform 3]

--- a/docs/topics/wildfly-swarm/docs/concepts/fractions.adoc
+++ b/docs/topics/wildfly-swarm/docs/concepts/fractions.adoc
@@ -1,12 +1,12 @@
 [#fractions]
 = Fractions
 
-WildFly Swarm is defined by an unbounded set of capabilities.
+{Thorntail} is defined by an unbounded set of capabilities.
 Each piece of functionality is called a _fraction._
 Some fractions provide only access to APIs, such as JAX-RS or CDI; other fractions provide higher-level capabilities, such as integration with RHSSO (Keycloak).
 
-The typical method for consuming WildFly Swarm fractions is through Maven coordinates, which you add to the `pom.xml` file in your application.
+The typical method for consuming {Thorntail} fractions is through Maven coordinates, which you add to the `pom.xml` file in your application.
 The functionality the fraction provides is then packaged with your application (see xref:creating-an-uberjar[]).
 
-To enable easier consumption of WildFly Swarm fractions, a bill of materials (BOM) is available. For more information, see xref:using-a-bom[].
+To enable easier consumption of {Thorntail} fractions, a bill of materials (BOM) is available. For more information, see xref:using-a-bom[].
 

--- a/docs/topics/wildfly-swarm/docs/concepts/packaging-types.adoc
+++ b/docs/topics/wildfly-swarm/docs/concepts/packaging-types.adoc
@@ -1,7 +1,7 @@
 [#packaging_types]
 = Packaging Types
 
-When using WildFly Swarm, there are the following ways to package your
+When using {Thorntail}, there are the following ways to package your
 runtime and application, depending on how you intend to use and deploy
 it:
 
@@ -18,7 +18,7 @@ An uberjar is useful for many continuous integration and continuous deployment
 and moved through the testing, validation, and production environments in your
 organization.
 
-The names of the uberjars that WildFly Swarm produces include the name of your
+The names of the uberjars that {Thorntail} produces include the name of your
 application and the `-swarm.jar` suffix.
 
 An uberjar can be executed like any executable JAR:
@@ -28,7 +28,6 @@ An uberjar can be executed like any executable JAR:
 $ java -jar myapp-swarm.jar
 ----
 
-ifndef::product[]
 [#hollow-jar]
 == Hollow JAR
 
@@ -41,7 +40,7 @@ in a container image lower in the image hierarchy--which means it changes less
 often--so that the higher layer which contains only your application code can
 be rebuilt more quickly.
 
-The names of the hollow JARs that WildFly Swarm produces include the name of
+The names of the hollow JARs that {Thorntail} produces include the name of
 your application, and the `-hollow-swarm.jar` suffix. You must package the
 `.war` file of your application separately in order to benefit from the hollow
 JAR.
@@ -53,5 +52,45 @@ executing the hollow JAR:
 ----
 $ java -jar myapp-hollow-swarm.jar myapp.war
 ----
+
+=== Pre-Built Hollow JARs
+
+{Thorntail} ships the following pre-built hollow JARs:
+
+ifndef::product[]
+full:: The main Java EE related capabilities
 endif::[]
+web:: Functionality focused on web technologies
+microprofile:: Functionality defined by all Eclipse MicroProfile specifications
+
+The hollow JARs are available under the following coordinates:
+
+[source,xml,options="nowrap",subs="attributes+"]
+----
+<dependency>
+    <groupId>org.wildfly.swarm.servers</groupId>
+ifndef::product[    <artifactId>[full|web|microprofile]</artifactId>]
+ifdef::product[    <artifactId>[web|microprofile]</artifactId>]
+</dependency>
+----
+
+[NOTE]
+====
+anchor:hollow-jar-limitations[]Using hollow JARs has certain limitations:
+
+* To enable {Thorntail} to autodetect a JDBC driver, you must add the JAR with the driver to the `swarm.classpath` system property, for example:
++
+[source,bash,options="nowrap"]
+----
+$ java -Dswarm.classpath=./h2-1.4.196.jar -jar my-hollow-swarm.jar myApp.war
+----
+
+* YAML configuration files in your application are not automatically applied.
+You must specify them manually, for example:
++
+[source,bash,options="nowrap"]
+----
+$ java -jar my-hollow-swarm.jar myApp.war -s ./project-defaults.yml
+----
+====
 

--- a/docs/topics/wildfly-swarm/docs/howto/autodetect-fractions/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/autodetect-fractions/index.adoc
@@ -1,10 +1,10 @@
 [#auto-detecting-fractions]
 = Auto-detecting fractions
 
-Migrating existing legacy applications to benefit from WildFly Swarm is simple when using fraction auto-detection.
-If you enable the WildFly Swarm Maven plugin in your application, WildFly Swarm detects which APIs you use, and includes the appropriate fractions at build time.
+Migrating existing legacy applications to benefit from {Thorntail} is simple when using fraction auto-detection.
+If you enable the {Thorntail} Maven plugin in your application, {Thorntail} detects which APIs you use, and includes the appropriate fractions at build time.
 
-NOTE: By default, WildFly Swarm only auto-detects if you do not specify any fractions explicitly. This behavior is controlled by the `fractionDetectMode` property. For more information, see the xref:maven-plugin-configuration[Maven plugin configuration reference].
+NOTE: By default, {Thorntail} only auto-detects if you do not specify any fractions explicitly. This behavior is controlled by the `fractionDetectMode` property. For more information, see the xref:maven-plugin-configuration[Maven plugin configuration reference].
 
 For example, consider your `pom.xml` already specifies the API `.jar` file for a specification such as JAX-RS:
 
@@ -15,7 +15,7 @@ include::pom.xml[tag=jaxrs,index=2]
 </dependencies>
 ----
 
-WildFly Swarm then includes the `jaxrs` fraction during the build automatically.
+{Thorntail} then includes the `jaxrs` fraction during the build automatically.
 
 .Prerequisites
 

--- a/docs/topics/wildfly-swarm/docs/howto/autodetect-fractions/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/autodetect-fractions/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -116,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
@@ -1,11 +1,11 @@
 [#auto-detecting-jdbc-drivers]
 = Auto-detecting JDBC drivers
 
-WildFly Swarm has the capability to detect, install, and register
+{Thorntail} has the capability to detect, install, and register
 a variety of JDBC drivers based on their inclusion as a dependency
 to your application.
 
-The drivers that WildFly Swarm auto-detects include:
+The drivers that {Thorntail} auto-detects include:
 
 * H2
 * MySQL

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-datasource/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-datasource/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-fraction/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-fraction/index.adoc
@@ -2,14 +2,14 @@
 
 ## Introduction
 
-The composable pieces of WildFly Swarm are called _fractions_. Each fraction
+The composable pieces of {Thorntail} are called _fractions_. Each fraction
 starts with a single Maven-addressable artifact which may transitively bring
 in others.
 
 ## The `pom.xml`
 
 It is useful to set at least a pair of properties, specifying the version
-of the WildFly Swarm SPI and fraction-plugin being used:
+of the {Thorntail} SPI and fraction-plugin being used:
 
 [source,xml,subs=+attributes]
 ----
@@ -19,7 +19,7 @@ of the WildFly Swarm SPI and fraction-plugin being used:
 </properties>
 ----
 
-You can include all of the primary bits of WildFly Swarm using the
+You can include all of the primary bits of {Thorntail} using the
 `bom-all` artifact in a `<dependencyManagement>` import. Additionally,
 you'll need two more dependencies added in order to write CDI components
 to configure the server.
@@ -83,22 +83,30 @@ a fraction contributes configuration or capabilities to a runtime system.
 
 ### Package Layout
 
-For a given fraction, a unique package root is required.  In the usual
-case of the core code, it matches the pattern of `org.wildfly.swarm._CAPABILITY_`,
+For a given fraction, a unique package root is required.
+In the usual case of the core code, it matches the pattern of `org.wildfly.swarm._CAPABILITY_`,
 such as `org.wildfly.swarm.undertow` or `org.wildfly.swarm.naming`.
 
-Within the root may be two (or more) additional sub-packages, named
-'runtime' and 'deployment'.
+Within the root there may be additional sub-packages with special meaning:
 
-The `org.wildfly.swarm._CAPABILITY_.runtime` package holds classes that are
+* The `org.wildfly.swarm._CAPABILITY_.runtime` package holds classes that are
 considered "back-end" components, loaded via our internal CDI implementation
 in order to configure and setup the server.
-
-The `org.wildfly.swarm._CAPABILITY_.deployment` package holds other classes
+* The `org.wildfly.swarm._CAPABILITY_.deployment` package holds other classes
 that should not be considered either part of the front-end API of the fraction
 exposed to users, nor a part of the back-end components to configure the
 server.  Instead, the `.deployment` package is a sidecar to hold additional
 classes that may be added to deployment archives.
+* The `org.wildfly.swarm._CAPABILITY_.detect` package holds fraction autodetection logic classes.
+See also <<auto-detection>>.
+
+The `wildfly-swarm-fraction-plugin` automatically generates a number of `module.xml` descriptors depending on what features it has found in the fraction.
+Each generated module descriptor is used to isolate a particular part of a fraction functionality.
+E.g. a fraction module with `deployment` slot (which includes the content of `org.wildfly.swarm._CAPABILITY_.deployment`) is automatically added as a module dependency to any deployment.
+It’s a convenient way to add code into the user deployment for handling integrations with the container.
+Or, for example, a fraction module with `runtime` slot is used to load the fraction and any of its runtime code.
+
+NOTE: The generated descriptors may be overriden by providing the corresponding module.xml in the `src/main/resources/modules` directory.
 
 ### The `module.conf`
 
@@ -165,12 +173,12 @@ Within the `runtime` sub-package of the fraction, a variety of CDI-enabled
 components may be used.  Within these classes, you can use typical CDI mechanisms
 such as `@Inject`, `@Produces`, and `Instance<>` in order to accomplish whatever
 is required for your fraction.  Typically these components would, at the minimum,
-inject their own fraction. They should each be marked as `@ApplicationScoped`.
+inject their own fraction.
 
 [source,java]
 ----
 @ApplicationScoped
-public class MyComponents implements Whatever {
+public class MyComponent implements Whatever {
 
   @Inject
   private MyFraction myFraction;
@@ -178,41 +186,27 @@ public class MyComponents implements Whatever {
 }
 ----
 
-#### `ArchivePreparer`
+#### `DeploymentProcessor`
 
-If your fraction needs an opportunity to alter or otherwise prepare all deployed
-archives, you may implement the `org.wildfly.swarm.spi.api.ArchivePreparer` interface.
+If your fraction needs an opportunity to process the deployment, e.g. to alter or otherwise prepare the deployed archive or to process Jandex metadata of the deployed
+archive, you may implement the `org.wildfly.swarm.spi.api.DeploymentProcessor` interface. The implementation class should be marked as `@DeploymentScoped`.
 
 [source,java]
 ----
-@ApplicationScoped
-public class MyArchivePreparer implements ArchivePreparer {
+@DeploymentScoped
+public class MyDeploymentProcessor implements DeploymentProcessor {
 
   @Inject
   private MyFraction myFraction;
 
-  public void prepareArchive(Archive<?> archive) {
-    archive.as( WARArchive.class ).setContextRoot( myFraction.getContextRoot() );
-  }
-}
-----
-
-#### `ArchiveMetadataProcessor`
-
-If your fraction needs an opportunity to process the Jandex metadata of all deployed
-archives, you may implement the `org.wildfly.swarm.spi.api.ArchiveMetadataProcessor`
-interface.
-
-[source,java]
-----
-@ApplicationScoped
-public class MyArchiveMetadataProcessor implements ArchiveMetadataProcessor {
+  @Inject
+  private Archive archive;
 
   @Inject
-  private MyFraction myFraction;
+  private IndexView index;
 
-  public void processArchive(Archive<?> archive, Index index) {
-    // ...
+  public void process() {
+     archive.as(WARArchive.class).setContextRoot(myFraction.getContextRoot());
   }
 }
 
@@ -277,7 +271,7 @@ public MyArchiveProducers {
 #### `@Configurable` and `Defaultable<>`
 
 When creating a new `Fraction` implementation, each of its fields
-will automatically be configurable through the `project-*.yml` 
+will automatically be configurable through the `project-*.yml`
 mechanisms.  In the case that different names for the configurable
 items are desired, the `@Configuration` annotation may be used.
 
@@ -314,11 +308,12 @@ Generally speaking, it is easier to push all configurable bits to the
 related `*Fraction` implementation, and `@Inject` the fraction into
 the relevant CDI components.
 
+[[auto-detection]]
 ### Auto-detection
 
-An important point of WildFly Swarm is the capability of the plugin
+An important point of {Thorntail} is the capability of the plugin
 to autodetect that a fraction is required.  Currently this is only supported
-by fractions that are part of the core WildFly Swarm distribution. In
+by fractions that are part of the core {Thorntail} distribution. In
 the event that your fraction is merged into core, you will want to possibly
 also support auto-detection.
 
@@ -409,7 +404,7 @@ public interface MyFractionMessages extends BasicLogger {
 }
 ----
 
-Now, typesafe logging may occur such as 
+Now, typesafe logging may occur such as
 
 [source,java]
 ----

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-fraction/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-fraction/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-hollow-jar/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-hollow-jar/index.adoc
@@ -1,7 +1,7 @@
 [#creating-a-hollow-jar]
 = Creating a hollow JAR
 
-The xref:hollow-jar[hollow JAR] is one method of packaging an application for execution with WildFly Swarm.
+The xref:hollow-jar[hollow JAR] is one method of packaging an application for execution with {Thorntail}.
 
 .Prerequisites
 
@@ -43,4 +43,5 @@ $ java -jar ./target/myapp-hollow-swarm.jar ./target/myapp.war
 
 * xref:hollow-jar[]
 * xref:creating-an-uberjar[]
+* xref:hollow-jar-limitations[Limitations of using hollow JARs]
 

--- a/docs/topics/wildfly-swarm/docs/howto/create-a-hollow-jar/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/create-a-hollow-jar/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/create-an-uberjar/index.adoc
@@ -2,7 +2,7 @@
 = Creating an Uberjar
 
 One method of packaging an application for execution
-with WildFly Swarm is as an _uberjar_. 
+with {Thorntail} is as an _uberjar_. 
 
 .Prerequisites
 

--- a/docs/topics/wildfly-swarm/docs/howto/create-an-uberjar/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/create-an-uberjar/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -116,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/enabling-logging/index.adoc
@@ -2,7 +2,7 @@
 [#enabling-logging_{context}]
 = Enabling logging
 
-Each WildFly Swarm fraction is dependent on the Logging fraction, which means that if you use any WildFly Swarm fraction in your application, logging is automatically enabled on the `INFO` level and higher.
+Each {Thorntail} fraction is dependent on the Logging fraction, which means that if you use any {Thorntail} fraction in your application, logging is automatically enabled on the `INFO` level and higher.
 If you want to enable logging explicitly, add the Logging fraction to the POM file of your application.
 
 .Prerequisites

--- a/docs/topics/wildfly-swarm/docs/howto/explicit-fractions/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/explicit-fractions/index.adoc
@@ -11,9 +11,9 @@ When writing your application from scratch, ensure it compiles correctly and use
 
 . Add the BOM to your `pom.xml`. For more information, see xref:using-a-bom[].
 
-. Add the WildFly Swarm Maven plugin to your `pom.xml`. For more information, see xref:creating-an-uberjar[].
+. Add the {Thorntail} Maven plugin to your `pom.xml`. For more information, see xref:creating-an-uberjar[].
 
-. Add one or more dependencies on WildFly Swarm fractions to the `pom.xml` file:
+. Add one or more dependencies on {Thorntail} fractions to the `pom.xml` file:
 +
 [source,xml]
 ----

--- a/docs/topics/wildfly-swarm/docs/howto/explicit-fractions/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/explicit-fractions/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -116,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/logging-to-a-file/index.adoc
@@ -5,7 +5,7 @@
 In addition to the console logging, you can save the logs of your application in a file.
 Typically, deployments use rotating logs to save disk space.
 
-In WildFly Swarm, logging is configured using system properties.
+In {Thorntail}, logging is configured using system properties.
 Even though it is possible to use the `-Dproperty=value` syntax when launching your application, it is strongly recommended to configure file logging using the YAML profile files.
 
 .Prerequisites
@@ -60,7 +60,7 @@ periodic-rotating-file-handlers:
 
 Here, a new handler named `FILE` is created, logging events of the `INFO` level and higher.
 It logs in the `target` directory, and each log file is named `MY_APP_NAME.log` with the suffix `.yyyy-MM-dd`.
-WildFly Swarm automatically parses the log rotation period from the suffix, so ensure you use a format compatible with the `java.text.SimpleDateFormat` class.
+{Thorntail} automatically parses the log rotation period from the suffix, so ensure you use a format compatible with the `java.text.SimpleDateFormat` class.
 --
 
 . Configure the root logger.

--- a/docs/topics/wildfly-swarm/docs/howto/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/pom.xml
@@ -9,13 +9,13 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-parent</artifactId>
-  <version>7.0.1</version>
+  <version>7.1.0</version>
 
   <name>WildFly Swarm HOWTO: Parent</name>
   <packaging>pom</packaging>
 
   <properties>
-    <version.wildfly-swarm>${project.version}</version.wildfly-swarm>
+    <version.wildfly-swarm>7.1.0</version.wildfly-swarm>
     <version.maven-war-plugin>2.2</version.maven-war-plugin>
     <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
     <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>

--- a/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/test-in-container/index.adoc
@@ -3,8 +3,8 @@
 
 Using Arquillian, you have the capability of injecting unit tests into a
 running application. This allows you to verify your application is behaving
-correctly. There is an adapter for WildFly Swarm that makes Arquillian-based
-testing work well with WildFly Swarm{ndash}based applications.
+correctly. There is an adapter for {Thorntail} that makes Arquillian-based
+testing work well with {Thorntail}{ndash}based applications.
 
 .Prerequisites
 
@@ -12,7 +12,7 @@ testing work well with WildFly Swarm{ndash}based applications.
 
 .Procedure
 
-. Include the WildFly Swarm BOM as described in xref:using-a-bom[]:
+. Include the {Thorntail} BOM as described in xref:using-a-bom[]:
 +
 [source,xml]
 ----
@@ -22,29 +22,6 @@ include::pom.xml[tag=bom,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
-
-ifdef::product[]
-. If your test uses the Apache HTTP Client or the JAX-RS Client, add the `commons-logging` artifact to the `test` scope of the project in the `pom.xml` file:
-+
---
-[source,xml]
-----
-<project>
-  <dependencies>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
-      <scope>test</scope>
-    <dependency>
-  </dependencies>
-</project>
-----
-
-The reason is that the WildFly Swarm productized rutime artifact BOM imports the EAP runtime artifacts BOM (`org.jboss.bom:eap-runtime-artifacts`), which excludes the `commons-logging` artifact from the `org.apache.httpcomponents:httpclient` and `org.apache.james:apache-mime4j` artifacts.
-As a result, when running tests in a Maven project that imports the WildFly Swarm productized runtime artifact BOM, neither the Apache HTTP Client nor any other artifact that depends on it (for example, the JAX-RS Client) works.
---
-endif::[]
 
 . Reference the `org.wildfly.swarm:arquillian` artifact in your `pom.xml` file
 with the `<scope>` set to `test`:
@@ -68,7 +45,7 @@ include::src/main/resources/project-defaults.yml[]
 
 . Create a test class.
 +
-NOTE: Creating an Arquillian test before WildFly Swarm existed usually involved
+NOTE: Creating an Arquillian test before {Thorntail} existed usually involved
 programatically creating `Archive` due to the fact that applications
 were larger, and the aim was to test a single component in isolation.
 +
@@ -97,7 +74,7 @@ include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[
 ----
 
 Using the `@DefaultDeployment` annotation provided by Arquillian integration
-with WildFly Swarm means you should _not_ use the Arquillian `@Deployment`
+with {Thorntail} means you should _not_ use the Arquillian `@Deployment`
 annotation on static methods that return an `Archive`.
 
 The `@DefaultDeployment` annotation inspects the package of the test:

--- a/docs/topics/wildfly-swarm/docs/howto/test-in-container/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/test-in-container/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/topics/wildfly-swarm/docs/howto/use-a-bom/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/use-a-bom/index.adoc
@@ -1,9 +1,9 @@
 [#using-a-bom]
 = Using a BOM
 
-To explicitly specify the WildFly Swarm
+To explicitly specify the {Thorntail}
 fractions your application uses, instead of relying
-on auto-detection, WildFly Swarm includes a set of
+on auto-detection, {Thorntail} includes a set of
 BOMs (bill of materials) which you can use instead of
 having to track and update Maven artifact versions
 in several places.
@@ -11,7 +11,7 @@ in several places.
 ifndef::product[]
 == Different types of BOMs
 
-WildFly Swarm is described as _just enough app-server,_
+{Thorntail} is described as _just enough app-server,_
 which means it comprises of multiple pieces.  Your application
 includes only the pieces it needs.
 
@@ -55,7 +55,7 @@ endif::[]
 . Include a `bom` artifact in your `pom.xml`.
 +
 --
-Tracking the current version of WildFly Swarm through a property in your
+Tracking the current version of {Thorntail} through a property in your
 `pom.xml` is recommended.
 
 [source,xml,subs="+attributes"]
@@ -105,20 +105,20 @@ endif::[]
 By including the BOMs of your choice in the `<dependencyManagement>` section,
 you have:
 
-* Provided version-management for any WildFly Swarm artifacts you
+* Provided version-management for any {Thorntail} artifacts you
 subsequently *choose* to use.
 * Provided support to your IDE for auto-completing known artifacts
 when you edit your the `pom.xml` file of your application.
 --
 
-. Include WildFly Swarm dependencies.
+. Include {Thorntail} dependencies.
 +
 --
-Even though you imported the WildFly Swarm BOMs in the `<dependencyManagement>`
-section, your application still has no dependencies on WildFly Swarm
+Even though you imported the {Thorntail} BOMs in the `<dependencyManagement>`
+section, your application still has no dependencies on {Thorntail}
 artifacts.
 
-To include WildFly Swarm artifact dependencies based on the capabilities your
+To include {Thorntail} artifact dependencies based on the capabilities your
 application, enter the relevant artifacts as `<dependency>` elements:
 
 NOTE: You do not have to specify the version of the artifacts because the BOM
@@ -140,10 +140,10 @@ for example `undertow`.
 
 One shortcoming of importing a Maven BOM import is that it does not
 handle the configuration on the level of `<pluginManagement>`. When you use the
-WildFly Swarm Maven Plugin, you must specify the version of the plugin to use.
+{Thorntail} Maven Plugin, you must specify the version of the plugin to use.
 
 Thanks to the property you use in your `pom.xml` file, you can easily ensure
-that your plugin usage matches the release of WildFly Swarm that you are
+that your plugin usage matches the release of {Thorntail} that you are
 targeting with the BOM import.
 
 [source,xml]

--- a/docs/topics/wildfly-swarm/docs/howto/use-a-bom/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/howto/use-a-bom/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.howto</groupId>
@@ -14,7 +13,7 @@
    <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -24,7 +23,7 @@
 
   <properties>
     <!-- tag::property[] -->
-    <version.wildfly-swarm>7.0.1</version.wildfly-swarm>
+    <version.wildfly-swarm>7.1.0</version.wildfly-swarm>
     <!-- end::property[] -->
   </properties>
 

--- a/docs/topics/wildfly-swarm/docs/howto/writing-an-application-from-scratch/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/howto/writing-an-application-from-scratch/index.adoc
@@ -2,7 +2,7 @@
 [id='writing-an-application-from-scratch_{context}']
 = Creating an application from scratch
 
-Creating a simple WildFly Swarm{ndash}based application with a REST endpoint from scratch.
+Creating a simple {Thorntail}{ndash}based application with a REST endpoint from scratch.
 
 [discrete]
 == Prerequisites
@@ -72,9 +72,9 @@ $ mvn wildfly-swarm:run
 
 Accessing the `http://localhost:8080/rest/hello` URL in your browser should return the following message:
 
-[source]
+[source,subs="attributes+"]
 ----
-Hello from WildFly Swarm!
+Hello from {Thorntail}!
 ----
 
 After finishing the procedure, there should be a directory on your hard drive with the following contents:

--- a/docs/topics/wildfly-swarm/docs/reference/configuration.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/configuration.adoc
@@ -1,7 +1,7 @@
 [#configuring-a-wildfly-swarm-application]
-= Configuring a WildFly Swarm application
+= Configuring a {Thorntail} application
 
-You can configure numerous options with applications built with WildFly Swarm.
+You can configure numerous options with applications built with {Thorntail}.
 For all options, reasonable defaults are already applied, so you do not have to change any options unless you explicitly want to.
 
 This reference is a complete list of all configurable items, grouped by the fraction that introduces them.
@@ -67,6 +67,20 @@ To use a property on the command line, pass it as a command-line parameter to th
 $ java -Dswarm.bind.address=127.0.0.1 -jar myapp-swarm.jar
 ----
 
+[discrete]
+==== Specifying JDBC drivers for hollow JARs
+
+When executing a hollow JAR, you can specify a JDBC Driver JAR using the `swarm.classpath` property.
+This way, you do not need to package the driver in the hollow JAR.
+
+[source,bash]
+----
+$ java -Dswarm.classpath=./h2-1.4.196.jar -jar microprofile-jpa-hollow-swarm.jar example-jpa-jaxrs-cdi.war
+----
+
+The `swarm.classpath` property accepts one or more paths to JAR files separated by `;`.
+The specified JAR files are added to the classpath of the application.
+
 [#configuring-an-application-using-yaml]
 == Configuring an application using YAML
 
@@ -95,7 +109,7 @@ swarm:
 [discrete]
 === Default YAML Files
 
-If the original `.war` file with your application contains a file named `project-defaults.yml`, that file represents the defaults applied over the absolute defaults that WildFly Swarm provides.
+If the original `.war` file with your application contains a file named `project-defaults.yml`, that file represents the defaults applied over the absolute defaults that {Thorntail} provides.
 
 In addition to the `project-defaults.yml` file, you can provide specific configuration files using the `-S <name>` command-line option.
 The specified files are loaded, in the order you provided them, before `project-defaults.yml`.

--- a/docs/topics/wildfly-swarm/docs/reference/elytron.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/elytron.adoc
@@ -1,0 +1,15 @@
+= Elytron configuration 
+
+Elytron by default will generate an audit log to the same directory that a {Thorntail} application is run. 
+However, in some environments (e.g., cloud), it may be necessary to relocate the audit file to a globally writable directory.
+
+Specify the following in your project-defaults.yml:
+[source,text]
+----
+swarm:
+  elytron:
+    file-audit-logs:
+      local-audit:
+        path: /tmp/audit.log
+----
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/archaius.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/archaius.adoc
@@ -1,6 +1,4 @@
-= JSON-P
-
-Provides support for JSON Processing according to JSR-353.
+= Archaius
 
 
 .Maven Coordinates
@@ -8,7 +6,7 @@ Provides support for JSON Processing according to JSR-353.
 ----
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>jsonp</artifactId>
+  <artifactId>archaius</artifactId>
 </dependency>
 ----
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/bean-validation.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/bean-validation.adoc
@@ -1,4 +1,4 @@
-# Bean Validation
+= Bean Validation
 
 Provides class-level constraint and validation according to JSR 303.
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/cdi.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/cdi.adoc
@@ -1,4 +1,4 @@
-# CDI
+= CDI
 
 Provides context and dependency-injection support according to JSR-299.
 
@@ -22,5 +22,8 @@ If true then the non-portable mode is enabled. The non-portable mode is suggeste
 
 swarm.cdi.require-bean-descriptor:: 
 If true then implicit bean archives without bean descriptor file (beans.xml) are ignored by Weld
+
+swarm.cdi.thread-pool-size:: 
+The number of threads to be used by the Weld thread pool. The pool is shared across all CDI-enabled deployments and used primarily for parallel Weld bootstrap.
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/connector.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/connector.adoc
@@ -1,4 +1,4 @@
-# Connector
+= Connector
 
 Primarily an internal fraction used to provide support for 
 higher-level fractions such as JCA (JSR-322).

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/datasources.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/datasources.adoc
@@ -1,12 +1,12 @@
-# Datasources Fraction
+= Datasources
 
 Provides support for container-managed database connections.
 
-## Autodetectable drivers
+== Autodetectable drivers
 
 If your application includes the appropriate vendor JDBC
 library in its normal dependencies, these drivers will be detected
-and installed by WildFly Swarm without any additional effort.
+and installed by {Thorntail} without any additional effort.
 
 The list of detectable drivers and their `driver-name` which
 may be used when defining a datasource is as follows:
@@ -141,6 +141,9 @@ The allocation retry wait millis element specifies the amount of time, in millis
 swarm.datasources.data-sources._KEY_.allow-multiple-users:: 
 Specifies if multiple users will access the datasource through the getConnection(user, password) method and hence if the internal pool type should account for that
 
+swarm.datasources.data-sources._KEY_.authentication-context:: 
+The Elytron authentication context which defines the javax.security.auth.Subject that is used to distinguish connections in the pool.
+
 swarm.datasources.data-sources._KEY_.background-validation:: 
 An element to specify that connections should be validated on a background thread versus being validated prior to use. Changing this value can be done only on disabled datasource,  requires a server restart otherwise.
 
@@ -180,6 +183,9 @@ Each connection-property specifies a string name/value pair with the property na
 swarm.datasources.data-sources._KEY_.connection-url:: 
 The JDBC driver connection URL
 
+swarm.datasources.data-sources._KEY_.credential-reference:: 
+Credential (from Credential Store) to authenticate on data source
+
 swarm.datasources.data-sources._KEY_.datasource-class:: 
 The fully qualified name of the JDBC datasource class
 
@@ -188,6 +194,9 @@ The fully qualified name of the JDBC driver class
 
 swarm.datasources.data-sources._KEY_.driver-name:: 
 Defines the JDBC driver the datasource should use. It is a symbolic name matching the the name of installed driver. In case the driver is deployed as jar, the name is the name of deployment unit
+
+swarm.datasources.data-sources._KEY_.elytron-enabled:: 
+Enables Elytron security for handling authentication of connections. The Elytron authentication-context to be used will be current context if no context is specified (see authentication-context).
 
 swarm.datasources.data-sources._KEY_.enlistment-trace:: 
 Defines if WildFly/IronJacamar should record enlistment traces
@@ -199,7 +208,7 @@ swarm.datasources.data-sources._KEY_.exception-sorter-properties::
 The exception sorter properties
 
 swarm.datasources.data-sources._KEY_.flush-strategy:: 
-Specifies how the pool should be flush in case of an error. Valid values are: FailingConnectionOnly (default), IdleConnections and EntirePool
+Specifies how the pool should be flush in case of an error.
 
 swarm.datasources.data-sources._KEY_.idle-timeout-minutes:: 
 The idle-timeout-minutes elements specifies the maximum time, in minutes, a connection may be idle before being closed. The actual maximum time depends also on the IdleRemover scan time, which is half of the smallest idle-timeout-minutes value of any pool. Changing this value can be done only on disabled datasource, requires a server restart otherwise.
@@ -229,7 +238,7 @@ swarm.datasources.data-sources._KEY_.password::
 Specifies the password used when creating a new connection
 
 swarm.datasources.data-sources._KEY_.pool-fair:: 
-Defines if pool should use be fair
+Defines if pool use should be fair
 
 swarm.datasources.data-sources._KEY_.pool-prefill:: 
 Should the pool be prefilled. Changing this value can be done only on disabled datasource, requires a server restart otherwise.
@@ -250,7 +259,7 @@ swarm.datasources.data-sources._KEY_.reauth-plugin-properties::
 The properties for the reauthentication plugin
 
 swarm.datasources.data-sources._KEY_.security-domain:: 
-Specifies the security domain which defines the javax.security.auth.Subject that are used to distinguish connections in the pool
+Specifies the PicketBox security domain which defines the PicketBox javax.security.auth.Subject that are used to distinguish connections in the pool
 
 swarm.datasources.data-sources._KEY_.set-tx-query-timeout:: 
 Whether to set the query timeout based on the time remaining until transaction timeout. Any configured query timeout will be used if there is no transaction
@@ -277,7 +286,7 @@ swarm.datasources.data-sources._KEY_.tracking::
 Defines if IronJacamar should track connection handles across transaction boundaries
 
 swarm.datasources.data-sources._KEY_.transaction-isolation:: 
-Set the java.sql.Connection transaction isolation level. Valid values are: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ, TRANSACTION_SERIALIZABLE and TRANSACTION_NONE
+Set the java.sql.Connection transaction isolation level. Valid values are: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ, TRANSACTION_SERIALIZABLE and TRANSACTION_NONE. Different values are used to set customLevel using TransactionIsolation#customLevel
 
 swarm.datasources.data-sources._KEY_.url-delimiter:: 
 Specifies the delimiter for URLs in connection-url for HA datasources
@@ -342,6 +351,9 @@ Whether or not the driver is JDBC compliant
 swarm.datasources.jdbc-drivers._KEY_.module-slot:: 
 The slot of the module from which the driver was loaded, if it was loaded from the module path
 
+swarm.datasources.jdbc-drivers._KEY_.profile:: 
+Domain Profile in which driver is defined. Null in case of standalone server
+
 swarm.datasources.jdbc-drivers._KEY_.xa-datasource-class:: 
 XA datasource class
 
@@ -354,11 +366,14 @@ The allocation retry wait millis element specifies the amount of time, in millis
 swarm.datasources.xa-data-sources._KEY_.allow-multiple-users:: 
 Specifies if multiple users will access the datasource through the getConnection(user, password) method and hence if the internal pool type should account for that
 
+swarm.datasources.xa-data-sources._KEY_.authentication-context:: 
+The Elytron authentication context which defines the javax.security.auth.Subject that is used to distinguish connections in the pool.
+
 swarm.datasources.xa-data-sources._KEY_.background-validation:: 
-An element to specify that connections should be validated on a background thread versus being validated prior to use. Changing this value can be done only on disabled datasource,  requires a server restart otherwise.
+An element to specify that connections should be validated on a background thread versus being validated prior to use.
 
 swarm.datasources.xa-data-sources._KEY_.background-validation-millis:: 
-The background-validation-millis element specifies the amount of time, in milliseconds, that background validation will run. Changing this value can be done only on disabled datasource,  requires a server restart otherwise
+The background-validation-millis element specifies the amount of time, in milliseconds, that background validation will run.
 
 swarm.datasources.xa-data-sources._KEY_.blocking-timeout-wait-millis:: 
 The blocking-timeout-millis element specifies the maximum time, in milliseconds, to block while waiting for a connection before throwing an exception. Note that this blocks only while waiting for locking a connection, and will never throw an exception if creating a new connection takes an inordinately long time
@@ -387,8 +402,14 @@ Speciefies class name extending org.jboss.jca.adapters.jdbc.spi.listener.Connect
 swarm.datasources.xa-data-sources._KEY_.connection-listener-property:: 
 Properties to be injected in class specified in connection-listener-class
 
+swarm.datasources.xa-data-sources._KEY_.credential-reference:: 
+Credential (from Credential Store) to authenticate on data source
+
 swarm.datasources.xa-data-sources._KEY_.driver-name:: 
 Defines the JDBC driver the datasource should use. It is a symbolic name matching the the name of installed driver. In case the driver is deployed as jar, the name is the name of deployment unit
+
+swarm.datasources.xa-data-sources._KEY_.elytron-enabled:: 
+Enables Elytron security for handling authentication of connections for recovery. The Elytron authentication-context to be used will be current context if no context is specified (see authentication-context).
 
 swarm.datasources.xa-data-sources._KEY_.enlistment-trace:: 
 Defines if WildFly/IronJacamar should record enlistment traces
@@ -400,7 +421,7 @@ swarm.datasources.xa-data-sources._KEY_.exception-sorter-properties::
 The exception sorter properties
 
 swarm.datasources.xa-data-sources._KEY_.flush-strategy:: 
-Specifies how the pool should be flush in case of an error. Valid values are: FailingConnectionOnly (default), IdleConnections and EntirePool
+Specifies how the pool should be flush in case of an error.
 
 swarm.datasources.xa-data-sources._KEY_.idle-timeout-minutes:: 
 The idle-timeout-minutes elements specifies the maximum time, in minutes, a connection may be idle before being closed. The actual maximum time depends also on the IdleRemover scan time, which is half of the smallest idle-timeout-minutes value of any pool. Changing this value can be done only on disabled datasource, requires a server restart otherwise.
@@ -439,7 +460,7 @@ swarm.datasources.xa-data-sources._KEY_.password::
 Specifies the password used when creating a new connection
 
 swarm.datasources.xa-data-sources._KEY_.pool-fair:: 
-Defines if pool should use be fair
+Defines if pool use should be fair
 
 swarm.datasources.xa-data-sources._KEY_.pool-prefill:: 
 Should the pool be prefilled. Changing this value can be done only on disabled datasource, requires a server restart otherwise.
@@ -458,6 +479,15 @@ The fully qualified class name of the reauthentication plugin implementation
 
 swarm.datasources.xa-data-sources._KEY_.reauth-plugin-properties:: 
 The properties for the reauthentication plugin
+
+swarm.datasources.xa-data-sources._KEY_.recovery-authentication-context:: 
+The Elytron authentication context which defines the javax.security.auth.Subject that is used to distinguish connections in the pool.
+
+swarm.datasources.xa-data-sources._KEY_.recovery-credential-reference:: 
+Credential (from Credential Store) to authenticate on data source
+
+swarm.datasources.xa-data-sources._KEY_.recovery-elytron-enabled:: 
+Enables Elytron security for handling authentication of connections for recovery. The Elytron authentication-context to be used will be current context if no context is specified (see authentication-context).
 
 swarm.datasources.xa-data-sources._KEY_.recovery-password:: 
 The password used for recovery
@@ -478,7 +508,7 @@ swarm.datasources.xa-data-sources._KEY_.same-rm-override::
 The is-same-rm-override element allows one to unconditionally set whether the javax.transaction.xa.XAResource.isSameRM(XAResource) returns true or false
 
 swarm.datasources.xa-data-sources._KEY_.security-domain:: 
-Specifies the security domain which defines the javax.security.auth.Subject that are used to distinguish connections in the pool
+Specifies the PicketBox security domain which defines the javax.security.auth.Subject that are used to distinguish connections in the pool
 
 swarm.datasources.xa-data-sources._KEY_.set-tx-query-timeout:: 
 Whether to set the query timeout based on the time remaining until transaction timeout. Any configured query timeout will be used if there is no transaction
@@ -505,7 +535,7 @@ swarm.datasources.xa-data-sources._KEY_.tracking::
 Defines if IronJacamar should track connection handles across transaction boundaries
 
 swarm.datasources.xa-data-sources._KEY_.transaction-isolation:: 
-Set the java.sql.Connection transaction isolation level. Valid values are: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ, TRANSACTION_SERIALIZABLE and TRANSACTION_NONE
+Set the java.sql.Connection transaction isolation level. Valid values are: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ, TRANSACTION_SERIALIZABLE and TRANSACTION_NONE. Different values are used to set customLevel using TransactionIsolation#customLevel.
 
 swarm.datasources.xa-data-sources._KEY_.url-delimiter:: 
 Specifies the delimiter for URLs in connection-url for HA datasources

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/ee.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/ee.adoc
@@ -1,4 +1,4 @@
-# EE
+= EE
 
 An internal fraction used to support other higher-level fractions. 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/ejb.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/ejb.adoc
@@ -12,202 +12,232 @@
 
 .Configuration
 
-swarm.ejb.async-service.thread-pool-name:: 
+swarm.ejb3.allow-ejb-name-regex:: 
+If this is true then regular expressions can be used in interceptor bindings to allow interceptors to be mapped to all beans that match the regular expression
+
+swarm.ejb3.application-security-domains._KEY_.enable-jacc:: 
+Enable authorization using JACC
+
+swarm.ejb3.application-security-domains._KEY_.referencing-deployments:: 
+The deployments currently referencing this mapping
+
+swarm.ejb3.application-security-domains._KEY_.security-domain:: 
+The Elytron security domain to be used by deployments that reference the mapped security domain
+
+swarm.ejb3.async-service.thread-pool-name:: 
 The name of the thread pool which handles asynchronous invocations
 
-swarm.ejb.caches._KEY_.aliases:: 
+swarm.ejb3.caches._KEY_.aliases:: 
 The aliases by which this cache may also be referenced
 
-swarm.ejb.caches._KEY_.passivation-store:: 
+swarm.ejb3.caches._KEY_.passivation-store:: 
 The passivation store used by this cache
 
-swarm.ejb.cluster-passivation-stores._KEY_.bean-cache:: 
+swarm.ejb3.cluster-passivation-stores._KEY_.bean-cache:: 
 The name of the cache used to store bean instances.
 
-swarm.ejb.cluster-passivation-stores._KEY_.cache-container:: 
+swarm.ejb3.cluster-passivation-stores._KEY_.cache-container:: 
 The name of the cache container used for the bean and client-mappings caches
 
-swarm.ejb.cluster-passivation-stores._KEY_.idle-timeout:: 
+swarm.ejb3.cluster-passivation-stores._KEY_.idle-timeout:: 
 The timeout in units specified by idle-timeout-unit, after which a bean will passivate
 
-swarm.ejb.cluster-passivation-stores._KEY_.max-size:: 
+swarm.ejb3.cluster-passivation-stores._KEY_.max-size:: 
 The maximum number of beans this cache should store before forcing old beans to passivate
 
-swarm.ejb.default-distinct-name:: 
+swarm.ejb3.default-clustered-sfsb-cache:: 
+Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level
+
+swarm.ejb3.default-distinct-name:: 
 The default distinct name that is applied to every EJB deployed on this server
 
-swarm.ejb.default-entity-bean-instance-pool:: 
+swarm.ejb3.default-entity-bean-instance-pool:: 
 Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level
 
-swarm.ejb.default-entity-bean-optimistic-locking:: 
+swarm.ejb3.default-entity-bean-optimistic-locking:: 
 If set to true entity beans will use optimistic locking by default
 
-swarm.ejb.default-mdb-instance-pool:: 
+swarm.ejb3.default-mdb-instance-pool:: 
 Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level
 
-swarm.ejb.default-missing-method-permissions-deny-access:: 
+swarm.ejb3.default-missing-method-permissions-deny-access:: 
 If this is set to true then methods on an EJB with a security domain specified or with other methods with security metadata will have an implicit @DenyAll unless other security metadata is present
 
-swarm.ejb.default-resource-adapter-name:: 
+swarm.ejb3.default-resource-adapter-name:: 
 Name of the default resource adapter name that will be used by MDBs, unless overridden at the deployment or bean level
 
-swarm.ejb.default-security-domain:: 
+swarm.ejb3.default-security-domain:: 
 The default security domain that will be used for EJBs if the bean doesn't explicitly specify one
 
-swarm.ejb.default-sfsb-cache:: 
+swarm.ejb3.default-sfsb-cache:: 
 Name of the default stateful bean cache, which will be applicable to all stateful EJBs, unless overridden at the deployment or bean level
 
-swarm.ejb.default-sfsb-passivation-disabled-cache:: 
+swarm.ejb3.default-sfsb-passivation-disabled-cache:: 
 Name of the default stateful bean cache, which will be applicable to all stateful EJBs which have passivation disabled. Each deployment or EJB can optionally override this cache name.
 
-swarm.ejb.default-singleton-bean-access-timeout:: 
+swarm.ejb3.default-singleton-bean-access-timeout:: 
 The default access timeout for singleton beans
 
-swarm.ejb.default-slsb-instance-pool:: 
+swarm.ejb3.default-slsb-instance-pool:: 
 Name of the default stateless bean instance pool, which will be applicable to all stateless EJBs, unless overridden at the deployment or bean level
 
-swarm.ejb.default-stateful-bean-access-timeout:: 
+swarm.ejb3.default-stateful-bean-access-timeout:: 
 The default access timeout for stateful beans
 
-swarm.ejb.enable-statistics:: 
-If set to true, enable the collection of invocation statistics.
+swarm.ejb3.disable-default-ejb-permissions:: 
+This deprecated attribute has no effect and will be removed in a future release; it may never be set to a "false" value
 
-swarm.ejb.file-passivation-stores._KEY_.idle-timeout:: 
+swarm.ejb3.enable-graceful-txn-shutdown:: 
+Enabling txn graceful shutdown will make the server wait for active EJB-related transactions to complete before suspending. For that reason, if the server is running on a cluster, the suspending cluster node may receive ejb requests until all active transactions are complete. To avoid this behavior, omit this tag.
+
+swarm.ejb3.enable-statistics:: 
+If set to true, enable the collection of invocation statistics. Deprecated in favour of "statistics-enabled"
+
+swarm.ejb3.file-passivation-stores._KEY_.idle-timeout:: 
 The timeout in units specified by idle-timeout-unit, after which a bean will passivate
 
-swarm.ejb.file-passivation-stores._KEY_.max-size:: 
+swarm.ejb3.file-passivation-stores._KEY_.max-size:: 
 The maximum number of beans this cache should store before forcing old beans to passivate
 
-swarm.ejb.iiop-service.enable-by-default:: 
+swarm.ejb3.identity-service.outflow-security-domains:: 
+References to security domains to attempt to outflow any established identity to
+
+swarm.ejb3.iiop-service.enable-by-default:: 
 If this is true EJB's will be exposed over IIOP by default, otherwise it needs to be explicitly enabled in the deployment descriptor
 
-swarm.ejb.iiop-service.use-qualified-name:: 
+swarm.ejb3.iiop-service.use-qualified-name:: 
 If true EJB names will be bound into the naming service with the application and module name prepended to the name (e.g. myapp/mymodule/MyEjb)
 
-swarm.ejb.in-vm-remote-interface-invocation-pass-by-value:: 
+swarm.ejb3.in-vm-remote-interface-invocation-pass-by-value:: 
 If set to false, the parameters to invocations on remote interface of an EJB, will be passed by reference. Else, the parameters will be passed by value.
 
-swarm.ejb.log-system-exceptions:: 
+swarm.ejb3.log-system-exceptions:: 
 If this is true then all EJB system (not application) exceptions will be logged. The EJB spec mandates this behaviour, however it is not recommended as it will often result in exceptions being logged twice (once by the EJB and once by the calling code)
 
-swarm.ejb.mdb-delivery-groups._KEY_.active:: 
+swarm.ejb3.mdb-delivery-groups._KEY_.active:: 
 Indicates if delivery for all MDBs belonging to this group is active
 
-swarm.ejb.passivation-stores._KEY_.bean-cache:: 
+swarm.ejb3.passivation-stores._KEY_.bean-cache:: 
 The name of the cache used to store bean instances.
 
-swarm.ejb.passivation-stores._KEY_.cache-container:: 
+swarm.ejb3.passivation-stores._KEY_.cache-container:: 
 The name of the cache container used for the bean and client-mappings caches
 
-swarm.ejb.passivation-stores._KEY_.max-size:: 
+swarm.ejb3.passivation-stores._KEY_.max-size:: 
 The maximum number of beans this cache should store before forcing old beans to passivate
 
-swarm.ejb.remote-service.channel-creation-options._KEY_.type:: 
+swarm.ejb3.remote-service.channel-creation-options._KEY_.type:: 
 The type of the channel creation option
 
-swarm.ejb.remote-service.channel-creation-options._KEY_.value:: 
+swarm.ejb3.remote-service.channel-creation-options._KEY_.value:: 
 The value for the EJB remote channel creation option
 
-swarm.ejb.remote-service.cluster:: 
+swarm.ejb3.remote-service.cluster:: 
 The name of the clustered cache container which will be used to store/access the client-mappings of the EJB remoting connector's socket-binding on each node, in the cluster
 
-swarm.ejb.remote-service.connector-ref:: 
+swarm.ejb3.remote-service.connector-ref:: 
 The name of the connector on which the EJB3 remoting channel is registered
 
-swarm.ejb.remote-service.execute-in-worker:: 
+swarm.ejb3.remote-service.execute-in-worker:: 
 If this is true the EJB request will be executed in the IO subsystems worker, otherwise it will dispatch to the EJB thread pool
 
-swarm.ejb.remote-service.thread-pool-name:: 
+swarm.ejb3.remote-service.thread-pool-name:: 
 The name of the thread pool that handles remote invocations
 
-swarm.ejb.remoting-profiles._KEY_.exclude-local-receiver:: 
+swarm.ejb3.remoting-profiles._KEY_.exclude-local-receiver:: 
 If set no local receiver is used in this profile
 
-swarm.ejb.remoting-profiles._KEY_.local-receiver-pass-by-value:: 
+swarm.ejb3.remoting-profiles._KEY_.local-receiver-pass-by-value:: 
 If set local receiver will pass ejb beans by value
 
-swarm.ejb.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.channel-creation-options._KEY_.type:: 
+swarm.ejb3.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.channel-creation-options._KEY_.type:: 
 The type of the channel creation option
 
-swarm.ejb.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.channel-creation-options._KEY_.value:: 
+swarm.ejb3.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.channel-creation-options._KEY_.value:: 
 The value for the EJB remote channel creation option
 
-swarm.ejb.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.connect-timeout:: 
+swarm.ejb3.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.connect-timeout:: 
 Remoting ejb receiver connect timeout
 
-swarm.ejb.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.outbound-connection-ref:: 
+swarm.ejb3.remoting-profiles._KEY_.remoting-ejb-receivers._KEY_.outbound-connection-ref:: 
 Name of outbound connection that will be used by the ejb receiver
 
-swarm.ejb.strict-max-bean-instance-pools._KEY_.derive-size:: 
-Specifies if and what the max pool size should be derived from. A value of 'none', the default, indicates that the explicit value of max-pool-size should be used. A value of 'from-worker-pools' indicates that the max pool size should be derived from the size of the total threads for all worker pools configured on the system. A value of 'from-cpu-count' indicates that the max pool size should be derived from the total number of processors available on the system. Note that the computation isn't a 1:1 mapping, the values may or may not be augmented by other factors.
+swarm.ejb3.remoting-profiles._KEY_.static-ejb-discovery:: 
+Describes static discovery config for EJB's
 
-swarm.ejb.strict-max-bean-instance-pools._KEY_.max-pool-size:: 
+swarm.ejb3.statistics-enabled:: 
+If set to true, enable the collection of invocation statistics.
+
+swarm.ejb3.strict-max-bean-instance-pools._KEY_.derive-size:: 
+Specifies if and what the max pool size should be derived from. An undefined value (or the deprecated value 'none' which is converted to undefined) indicates that the explicit value of max-pool-size should be used. A value of 'from-worker-pools' indicates that the max pool size should be derived from the size of the total threads for all worker pools configured on the system. A value of 'from-cpu-count' indicates that the max pool size should be derived from the total number of processors available on the system. Note that the computation isn't a 1:1 mapping, the values may or may not be augmented by other factors.
+
+swarm.ejb3.strict-max-bean-instance-pools._KEY_.max-pool-size:: 
 The maximum number of bean instances that the pool can hold at a given point in time
 
-swarm.ejb.strict-max-bean-instance-pools._KEY_.timeout:: 
+swarm.ejb3.strict-max-bean-instance-pools._KEY_.timeout:: 
 The maximum amount of time to wait for a bean instance to be available from the pool
 
-swarm.ejb.strict-max-bean-instance-pools._KEY_.timeout-unit:: 
+swarm.ejb3.strict-max-bean-instance-pools._KEY_.timeout-unit:: 
 The instance acquisition timeout unit
 
-swarm.ejb.thread-pools._KEY_.active-count:: 
+swarm.ejb3.thread-pools._KEY_.active-count:: 
 The approximate number of threads that are actively executing tasks.
 
-swarm.ejb.thread-pools._KEY_.completed-task-count:: 
+swarm.ejb3.thread-pools._KEY_.completed-task-count:: 
 The approximate total number of tasks that have completed execution.
 
-swarm.ejb.thread-pools._KEY_.current-thread-count:: 
+swarm.ejb3.thread-pools._KEY_.current-thread-count:: 
 The current number of threads in the pool.
 
-swarm.ejb.thread-pools._KEY_.keepalive-time:: 
+swarm.ejb3.thread-pools._KEY_.keepalive-time:: 
 Used to specify the amount of time that pool threads should be kept running when idle; if not specified, threads will run until the executor is shut down.
 
-swarm.ejb.thread-pools._KEY_.largest-thread-count:: 
+swarm.ejb3.thread-pools._KEY_.largest-thread-count:: 
 The largest number of threads that have ever simultaneously been in the pool.
 
-swarm.ejb.thread-pools._KEY_.max-threads:: 
+swarm.ejb3.thread-pools._KEY_.max-threads:: 
 The maximum thread pool size.
 
-swarm.ejb.thread-pools._KEY_.name:: 
+swarm.ejb3.thread-pools._KEY_.name:: 
 The name of the thread pool.
 
-swarm.ejb.thread-pools._KEY_.queue-size:: 
+swarm.ejb3.thread-pools._KEY_.queue-size:: 
 The queue size.
 
-swarm.ejb.thread-pools._KEY_.rejected-count:: 
+swarm.ejb3.thread-pools._KEY_.rejected-count:: 
 The number of tasks that have been rejected.
 
-swarm.ejb.thread-pools._KEY_.task-count:: 
+swarm.ejb3.thread-pools._KEY_.task-count:: 
 The approximate total number of tasks that have ever been scheduled for execution.
 
-swarm.ejb.thread-pools._KEY_.thread-factory:: 
+swarm.ejb3.thread-pools._KEY_.thread-factory:: 
 Specifies the name of a specific thread factory to use to create worker threads. If not defined an appropriate default thread factory will be used.
 
-swarm.ejb.timer-service.database-data-stores._KEY_.allow-execution:: 
+swarm.ejb3.timer-service.database-data-stores._KEY_.allow-execution:: 
 If this node is allowed to execute timers. If this is false then the timers will be added to the database, and another node may execute them. Note that depending on your refresh interval if you add timers with a very short delay they will not be executed until another node refreshes.
 
-swarm.ejb.timer-service.database-data-stores._KEY_.database:: 
+swarm.ejb3.timer-service.database-data-stores._KEY_.database:: 
 The type of database that is in use. SQL can be customised per database type.
 
-swarm.ejb.timer-service.database-data-stores._KEY_.datasource-jndi-name:: 
+swarm.ejb3.timer-service.database-data-stores._KEY_.datasource-jndi-name:: 
 The datasource that is used to persist the timers
 
-swarm.ejb.timer-service.database-data-stores._KEY_.partition:: 
+swarm.ejb3.timer-service.database-data-stores._KEY_.partition:: 
 The partition name. This should be set to a different value for every node that is sharing a database to prevent the same timer being loaded by multiple noded.
 
-swarm.ejb.timer-service.database-data-stores._KEY_.refresh-interval:: 
+swarm.ejb3.timer-service.database-data-stores._KEY_.refresh-interval:: 
 Interval between refreshing the current timer set against the underlying database. A low value means timers get picked up more quickly, but increase load on the database.
 
-swarm.ejb.timer-service.default-data-store:: 
+swarm.ejb3.timer-service.default-data-store:: 
 The default data store used for persistent timers
 
-swarm.ejb.timer-service.file-data-stores._KEY_.path:: 
+swarm.ejb3.timer-service.file-data-stores._KEY_.path:: 
 The directory to store persistent timer information in
 
-swarm.ejb.timer-service.file-data-stores._KEY_.relative-to:: 
+swarm.ejb3.timer-service.file-data-stores._KEY_.relative-to:: 
 The relative path that is used to resolve the timer data store location
 
-swarm.ejb.timer-service.thread-pool-name:: 
+swarm.ejb3.timer-service.thread-pool-name:: 
 The name of the thread pool used to run timer service invocations
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/elytron.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/elytron.adoc
@@ -1,0 +1,996 @@
+= Elytron
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>elytron</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.elytron.add-prefix-role-mappers._KEY_.prefix:: 
+The prefix to add to each role.
+
+swarm.elytron.add-suffix-role-mappers._KEY_.suffix:: 
+The suffix to add to each role.
+
+swarm.elytron.aggregate-http-server-mechanism-factories._KEY_.available-mechanisms:: 
+The HTTP mechanisms available from this factory instance.
+
+swarm.elytron.aggregate-http-server-mechanism-factories._KEY_.http-server-mechanism-factories:: 
+The referenced http server factories to aggregate.
+
+swarm.elytron.aggregate-principal-decoders._KEY_.principal-decoders:: 
+The referenced principal decoders to aggregate.
+
+swarm.elytron.aggregate-principal-transformers._KEY_.principal-transformers:: 
+The referenced principal transformers to aggregate.
+
+swarm.elytron.aggregate-providers._KEY_.providers:: 
+The referenced Provider[] resources to aggregate.
+
+swarm.elytron.aggregate-realms._KEY_.authentication-realm:: 
+Reference to the security realm to use for authentication steps (obtaining or validating credentials).
+
+swarm.elytron.aggregate-realms._KEY_.authorization-realm:: 
+Reference to the security realm to use for loading the identity for authorization steps (loading of the identity).
+
+swarm.elytron.aggregate-role-mappers._KEY_.role-mappers:: 
+The referenced role mappers to aggregate.
+
+swarm.elytron.aggregate-sasl-server-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this factory after all filtering has been applied.
+
+swarm.elytron.aggregate-sasl-server-factories._KEY_.sasl-server-factories:: 
+The referenced sasl server factories to aggregate.
+
+swarm.elytron.aggregate-security-event-listeners._KEY_.security-event-listeners:: 
+The referenced security event listener resources to aggregate.
+
+swarm.elytron.authentication-configurations._KEY_.anonymous:: 
+Enables anonymous authentication.
+
+swarm.elytron.authentication-configurations._KEY_.attribute-extends:: 
+A previously defined authentication configuration to extend.
+
+swarm.elytron.authentication-configurations._KEY_.authentication-name:: 
+The authentication name to use.
+
+swarm.elytron.authentication-configurations._KEY_.authorization-name:: 
+The authorization name to use.
+
+swarm.elytron.authentication-configurations._KEY_.credential-reference:: 
+The reference to credential stored in CredentialStore under defined alias or clear text password.
+
+swarm.elytron.authentication-configurations._KEY_.forwarding-mode:: 
+The type of security identity forwarding to use. A mode of 'authentication' forwarding forwards the principal and credential. A mode of 'authorization' forwards the authorization id, allowing for a different authentication identity.
+
+swarm.elytron.authentication-configurations._KEY_.host:: 
+The host to use.
+
+swarm.elytron.authentication-configurations._KEY_.kerberos-security-factory:: 
+Reference to a kerberos security factory used to obtain a GSS kerberos credential
+
+swarm.elytron.authentication-configurations._KEY_.mechanism-properties:: 
+Configuration properties for the SASL authentication mechanism.
+
+swarm.elytron.authentication-configurations._KEY_.port:: 
+The port to use.
+
+swarm.elytron.authentication-configurations._KEY_.protocol:: 
+The protocol to use.
+
+swarm.elytron.authentication-configurations._KEY_.realm:: 
+The realm to use.
+
+swarm.elytron.authentication-configurations._KEY_.sasl-mechanism-selector:: 
+The SASL mechanism selector string.
+
+swarm.elytron.authentication-configurations._KEY_.security-domain:: 
+Reference to a security domain to obtain a forwarded identity.
+
+swarm.elytron.authentication-contexts._KEY_.attribute-extends:: 
+A previously defined authentication context to extend.
+
+swarm.elytron.authentication-contexts._KEY_.match-rules:: 
+The match-rules for this authentication context.
+
+swarm.elytron.caching-realms._KEY_.maximum-age:: 
+The time in milliseconds that an item can stay in the cache.
+
+swarm.elytron.caching-realms._KEY_.maximum-entries:: 
+The maximum number of entries to keep in the cache.
+
+swarm.elytron.caching-realms._KEY_.realm:: 
+A reference to a cacheable security realm.
+
+swarm.elytron.chained-principal-transformers._KEY_.principal-transformers:: 
+The referenced principal transformers to chain.
+
+swarm.elytron.client-ssl-contexts._KEY_.active-session-count:: 
+The count of current active sessions.
+
+swarm.elytron.client-ssl-contexts._KEY_.cipher-suite-filter:: 
+The filter to apply to specify the enabled cipher suites.
+
+swarm.elytron.client-ssl-contexts._KEY_.key-manager:: 
+Reference to the key manager to use within the SSLContext.
+
+swarm.elytron.client-ssl-contexts._KEY_.protocols:: 
+The enabled protocols.
+
+swarm.elytron.client-ssl-contexts._KEY_.provider-name:: 
+The name of the provider to use. If not specified, all providers from providers will be passed to the SSLContext.
+
+swarm.elytron.client-ssl-contexts._KEY_.providers:: 
+The name of the providers to obtain the Provider[] to use to load the SSLContext.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.application-buffer-size:: 
+The application buffer size as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.cipher-suite:: 
+The selected cipher suite as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.creation-time:: 
+The creation time as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.last-accessed-time:: 
+The last accessed time as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.local-certificates:: 
+The local certificates from the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.local-principal:: 
+The local principal as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.packet-buffer-size:: 
+The packet buffer size as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-certificates:: 
+The peer certificates from the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-host:: 
+The peer host as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-port:: 
+The peer port as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-principal:: 
+The peer principal as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.protocol:: 
+The protocol as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.ssl-sessions._KEY_.valid:: 
+The validity of the session as reported by the SSLSession.
+
+swarm.elytron.client-ssl-contexts._KEY_.trust-manager:: 
+Reference to the trust manager to use within the SSLContext.
+
+swarm.elytron.concatenating-principal-decoders._KEY_.joiner:: 
+The string to use to join the results of the referenced principal decoders.
+
+swarm.elytron.concatenating-principal-decoders._KEY_.principal-decoders:: 
+The referenced principal decoders to concatenate.
+
+swarm.elytron.configurable-http-server-mechanism-factories._KEY_.available-mechanisms:: 
+The HTTP mechanisms available from this factory instance.
+
+swarm.elytron.configurable-http-server-mechanism-factories._KEY_.filters:: 
+Filtering to be applied to enable / disable mechanisms based on the name.
+
+swarm.elytron.configurable-http-server-mechanism-factories._KEY_.http-server-mechanism-factory:: 
+The http server factory to be wrapped.
+
+swarm.elytron.configurable-http-server-mechanism-factories._KEY_.properties:: 
+Custom properties to be passed in to the http server factory calls.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this factory after all filtering has been applied.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.filters:: 
+List of filters to be evaluated sequentially combining the results using 'or'.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.properties:: 
+Custom properties to be passed in to the sasl server factory calls.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.protocol:: 
+The protocol that should be passed into factory when creating the mechanism.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.sasl-server-factory:: 
+The sasl server factory to be wrapped.
+
+swarm.elytron.configurable-sasl-server-factories._KEY_.server-name:: 
+The server name that should be passed into factory when creating the mechanism.
+
+swarm.elytron.constant-permission-mappers._KEY_.permissions:: 
+The permissions to assign.
+
+swarm.elytron.constant-principal-decoders._KEY_.constant:: 
+The constant value the principal decoder will always return.
+
+swarm.elytron.constant-principal-transformers._KEY_.constant:: 
+The constant value this PrincipalTransformer will always return.
+
+swarm.elytron.constant-realm-mappers._KEY_.realm-name:: 
+The name of the constant realm to return.
+
+swarm.elytron.constant-role-mappers._KEY_.roles:: 
+The constant roles to be returned by this role mapper.
+
+swarm.elytron.credential-stores._KEY_.create:: 
+Specifies whether credential store should create storage when it doesn't exist.
+
+swarm.elytron.credential-stores._KEY_.credential-reference:: 
+Credential reference to be used to create protection parameter.
+
+swarm.elytron.credential-stores._KEY_.implementation-properties:: 
+Map of credentials store implementation specific properties.
+
+swarm.elytron.credential-stores._KEY_.location:: 
+File name of credential store storage.
+
+swarm.elytron.credential-stores._KEY_.modifiable:: 
+Specifies whether credential store is modifiable.
+
+swarm.elytron.credential-stores._KEY_.other-providers:: 
+The name of the providers defined within the subsystem to obtain the Providers to search for the one that can create the required JCA objects within credential store. This is valid only for key-store based CredentialStore. If this is not specified then the global list of Providers is used instead.
+
+swarm.elytron.credential-stores._KEY_.provider-name:: 
+The name of the provider to use to instantiate the CredentialStoreSpi. If the provider is not specified then the first provider found that can create an instance of the specified 'type' will be used.
+
+swarm.elytron.credential-stores._KEY_.providers:: 
+The name of the providers defined within the subsystem to obtain the Providers to search for the one that can create the required CredentialStore type. If this is not specified then the global list of Providers is used instead.
+
+swarm.elytron.credential-stores._KEY_.relative-to:: 
+A reference to a previously defined path that the file name is relative to.
+
+swarm.elytron.credential-stores._KEY_.state:: 
+The state of the underlying service that represents this credential store at runtime.
+
+swarm.elytron.credential-stores._KEY_.type:: 
+The credential store type, e.g. KeyStoreCredentialStore.
+
+swarm.elytron.custom-credential-security-factories._KEY_.class-name:: 
+The class name of the implementation of the custom security factory.
+
+swarm.elytron.custom-credential-security-factories._KEY_.configuration:: 
+The optional key/value configuration for the custom security factory.
+
+swarm.elytron.custom-credential-security-factories._KEY_.module:: 
+The module to use to load the custom security factory.
+
+swarm.elytron.custom-modifiable-realms._KEY_.class-name:: 
+The class name of the implementation of the custom realm.
+
+swarm.elytron.custom-modifiable-realms._KEY_.configuration:: 
+The optional key/value configuration for the custom realm.
+
+swarm.elytron.custom-modifiable-realms._KEY_.module:: 
+The module to use to load the custom realm.
+
+swarm.elytron.custom-permission-mappers._KEY_.class-name:: 
+Fully qualified class name of the permission mapper
+
+swarm.elytron.custom-permission-mappers._KEY_.configuration:: 
+The optional kay/value configuration for the permission mapper
+
+swarm.elytron.custom-permission-mappers._KEY_.module:: 
+Name of the module to use to load the permission mapper
+
+swarm.elytron.custom-principal-decoders._KEY_.class-name:: 
+Fully qualified class name of the principal decoder
+
+swarm.elytron.custom-principal-decoders._KEY_.configuration:: 
+The optional kay/value configuration for the principal decoder
+
+swarm.elytron.custom-principal-decoders._KEY_.module:: 
+Name of the module to use to load the principal decoder
+
+swarm.elytron.custom-principal-transformers._KEY_.class-name:: 
+The class name of the implementation of the custom principal transformer.
+
+swarm.elytron.custom-principal-transformers._KEY_.configuration:: 
+The optional key/value configuration for the custom principal transformer.
+
+swarm.elytron.custom-principal-transformers._KEY_.module:: 
+The module to use to load the custom principal transformer.
+
+swarm.elytron.custom-realm-mappers._KEY_.class-name:: 
+Fully qualified class name of the RealmMapper
+
+swarm.elytron.custom-realm-mappers._KEY_.configuration:: 
+The optional kay/value configuration for the RealmMapper
+
+swarm.elytron.custom-realm-mappers._KEY_.module:: 
+Name of the module to use to load the RealmMapper
+
+swarm.elytron.custom-realms._KEY_.class-name:: 
+The class name of the implementation of the custom realm.
+
+swarm.elytron.custom-realms._KEY_.configuration:: 
+The optional key/value configuration for the custom realm.
+
+swarm.elytron.custom-realms._KEY_.module:: 
+The module to use to load the custom realm.
+
+swarm.elytron.custom-role-decoders._KEY_.class-name:: 
+Fully qualified class name of the RoleDecoder
+
+swarm.elytron.custom-role-decoders._KEY_.configuration:: 
+The optional kay/value configuration for the RoleDecoder
+
+swarm.elytron.custom-role-decoders._KEY_.module:: 
+Name of the module to use to load the RoleDecoder
+
+swarm.elytron.custom-role-mappers._KEY_.class-name:: 
+Fully qualified class name of the RoleMapper
+
+swarm.elytron.custom-role-mappers._KEY_.configuration:: 
+The optional key/value configuration for the RoleMapper
+
+swarm.elytron.custom-role-mappers._KEY_.module:: 
+Name of the module to use to load the RoleMapper
+
+swarm.elytron.default-authentication-context:: 
+The default authentication context to be associated with all deployments.
+
+swarm.elytron.dir-contexts._KEY_.authentication-context:: 
+The authentication context to obtain login credentials to connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
+
+swarm.elytron.dir-contexts._KEY_.authentication-level:: 
+The authentication level (security level/authentication mechanism) to use. Corresponds to SECURITY_AUTHENTICATION ("java.naming.security.authentication") environment property. Allowed values: "none", "simple", sasl_mech, where sasl_mech is a space-separated list of SASL mechanism names.
+
+swarm.elytron.dir-contexts._KEY_.connection-timeout:: 
+The timeout for connecting to the LDAP server in milliseconds.
+
+swarm.elytron.dir-contexts._KEY_.credential-reference:: 
+The credential reference to authenticate and connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
+
+swarm.elytron.dir-contexts._KEY_.enable-connection-pooling:: 
+Indicates if connection pooling is enabled.
+
+swarm.elytron.dir-contexts._KEY_.module:: 
+Name of module that will be used as class loading base.
+
+swarm.elytron.dir-contexts._KEY_.principal:: 
+The principal to authenticate and connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
+
+swarm.elytron.dir-contexts._KEY_.properties:: 
+The additional connection properties for the DirContext.
+
+swarm.elytron.dir-contexts._KEY_.read-timeout:: 
+The read timeout for an LDAP operation in milliseconds.
+
+swarm.elytron.dir-contexts._KEY_.referral-mode:: 
+If referrals should be followed.
+
+swarm.elytron.dir-contexts._KEY_.ssl-context:: 
+The name of ssl-context used to secure connection to the LDAP server.
+
+swarm.elytron.dir-contexts._KEY_.url:: 
+The connection url.
+
+swarm.elytron.disallowed-providers:: 
+A list of providers that are not allowed, and will be removed from the providers list.
+
+swarm.elytron.file-audit-logs._KEY_.attribute-synchronized:: 
+Whether every event should be immediately synchronised to disk.
+
+swarm.elytron.file-audit-logs._KEY_.format:: 
+The format to use to record the audit event.
+
+swarm.elytron.file-audit-logs._KEY_.path:: 
+Path of the file to be written.
+
+swarm.elytron.file-audit-logs._KEY_.relative-to:: 
+The relative path to the audit log.
+
+swarm.elytron.filesystem-realms._KEY_.encoded:: 
+Whether the identity names should be stored encoded (Base32) in file names.
+
+swarm.elytron.filesystem-realms._KEY_.levels:: 
+The number of levels of directory hashing to apply.
+
+swarm.elytron.filesystem-realms._KEY_.path:: 
+The path to the file containing the realm.
+
+swarm.elytron.filesystem-realms._KEY_.relative-to:: 
+The pre-defined path the path is relative to.
+
+swarm.elytron.filtering-key-stores._KEY_.alias-filter:: 
+A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+
+swarm.elytron.filtering-key-stores._KEY_.key-store:: 
+Name of filtered KeyStore.
+
+swarm.elytron.filtering-key-stores._KEY_.state:: 
+The state of the underlying service that represents this KeyStore at runtime, if it is anything other than UP runtime operations will not be available.
+
+swarm.elytron.final-providers:: 
+Reference to the Providers that should be registered after all existing Providers.
+
+swarm.elytron.http-authentication-factories._KEY_.available-mechanisms:: 
+The HTTP mechanisms available from this configuration after all filtering has been applied.
+
+swarm.elytron.http-authentication-factories._KEY_.http-server-mechanism-factory:: 
+The HttpServerAuthenticationMechanismFactory to associate with this resource
+
+swarm.elytron.http-authentication-factories._KEY_.mechanism-configurations:: 
+Mechanism specific configuration
+
+swarm.elytron.http-authentication-factories._KEY_.security-domain:: 
+The SecurityDomain to associate with this resource
+
+swarm.elytron.identity-realms._KEY_.attribute-name:: 
+The name of the attribute associated with this identity.
+
+swarm.elytron.identity-realms._KEY_.attribute-values:: 
+The values associated with the identities attribute.
+
+swarm.elytron.identity-realms._KEY_.identity:: 
+The identity available from the security realm.
+
+swarm.elytron.initial-providers:: 
+Reference to the Providers that should be registered ahead of all existing Providers.
+
+swarm.elytron.jdbc-realms._KEY_.principal-query:: 
+The authentication query used to authenticate users based on specific key types.
+
+swarm.elytron.kerberos-security-factories._KEY_.debug:: 
+Should the JAAS step of obtaining the credential have debug logging enabled.
+
+swarm.elytron.kerberos-security-factories._KEY_.mechanism-names:: 
+The mechanism names the credential should be usable with. Names will be converted to OIDs and used together with OIDs from mechanism-oids attribute.
+
+swarm.elytron.kerberos-security-factories._KEY_.mechanism-oids:: 
+The mechanism OIDs the credential should be usable with. Will be used together with OIDs derived from names from mechanism-names attribute.
+
+swarm.elytron.kerberos-security-factories._KEY_.minimum-remaining-lifetime:: 
+How much lifetime (in seconds) should a cached credential have remaining before it is recreated.
+
+swarm.elytron.kerberos-security-factories._KEY_.obtain-kerberos-ticket:: 
+Should the KerberosTicket also be obtained and associated with the credential. This is required to be true where credentials are delegated to the server.
+
+swarm.elytron.kerberos-security-factories._KEY_.options:: 
+The Krb5LoginModule additional options.
+
+swarm.elytron.kerberos-security-factories._KEY_.path:: 
+The path of the KeyTab to load to obtain the credential.
+
+swarm.elytron.kerberos-security-factories._KEY_.principal:: 
+The principal represented by the KeyTab
+
+swarm.elytron.kerberos-security-factories._KEY_.relative-to:: 
+The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
+
+swarm.elytron.kerberos-security-factories._KEY_.request-lifetime:: 
+How much lifetime (in seconds) should be requested for newly created credentials.
+
+swarm.elytron.kerberos-security-factories._KEY_.required:: 
+Is the keytab file with adequate principal required to exist at the time the service starts?
+
+swarm.elytron.kerberos-security-factories._KEY_.server:: 
+If this for use server side or client side?
+
+swarm.elytron.kerberos-security-factories._KEY_.wrap-gss-credential:: 
+Should generated GSS credentials be wrapped to prevent improper disposal or not?
+
+swarm.elytron.key-managers._KEY_.algorithm:: 
+The name of the algorithm to use to create the underlying KeyManagerFactory.
+
+swarm.elytron.key-managers._KEY_.alias-filter:: 
+A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+
+swarm.elytron.key-managers._KEY_.credential-reference:: 
+The credential reference to decrypt KeyStore item. (Not a password of the KeyStore.)
+
+swarm.elytron.key-managers._KEY_.key-store:: 
+Reference to the KeyStore to use to initialise the underlying KeyManagerFactory.
+
+swarm.elytron.key-managers._KEY_.provider-name:: 
+The name of the provider to use to create the underlying KeyManagerFactory.
+
+swarm.elytron.key-managers._KEY_.providers:: 
+Reference to obtain the Provider[] to use when creating the underlying KeyManagerFactory.
+
+swarm.elytron.key-store-realms._KEY_.key-store:: 
+Reference to the KeyStore that should be used to back this security realm.
+
+swarm.elytron.key-stores._KEY_.alias-filter:: 
+A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+
+swarm.elytron.key-stores._KEY_.attribute-synchronized:: 
+The time this KeyStore was last loaded or saved. Note: Some providers may continue to apply updates after the KeyStore was loaded within the application server.
+
+swarm.elytron.key-stores._KEY_.credential-reference:: 
+The reference to credential stored in CredentialStore under defined alias or clear text password.
+
+swarm.elytron.key-stores._KEY_.loaded-provider:: 
+Information about the provider that was used for this KeyStore.
+
+swarm.elytron.key-stores._KEY_.modified:: 
+Indicates if the in-memory representation of the KeyStore has been changed since it was last loaded or stored.  Note: For some providers updates may be immediate without further load or store calls.
+
+swarm.elytron.key-stores._KEY_.path:: 
+The path to the KeyStore file.
+
+swarm.elytron.key-stores._KEY_.provider-name:: 
+The name of the provider to use to load the KeyStore, disables searching for the first Provider that can create a KeyStore of the specified type.
+
+swarm.elytron.key-stores._KEY_.providers:: 
+A reference to the providers that should be used to obtain the list of Provider instances to search, if not specified the global list of providers will be used instead.
+
+swarm.elytron.key-stores._KEY_.relative-to:: 
+The base path this store is relative to.
+
+swarm.elytron.key-stores._KEY_.required:: 
+Is the file required to exist at the time the KeyStore service starts?
+
+swarm.elytron.key-stores._KEY_.size:: 
+The number of entries in the KeyStore.
+
+swarm.elytron.key-stores._KEY_.state:: 
+The state of the underlying service that represents this KeyStore at runtime, if it is anything other than UP runtime operations will not be available.
+
+swarm.elytron.key-stores._KEY_.type:: 
+The type of the KeyStore, used when creating the new KeyStore instance.
+
+swarm.elytron.ldap-key-stores._KEY_.alias-attribute:: 
+The name of LDAP attribute, where will be item alias stored.
+
+swarm.elytron.ldap-key-stores._KEY_.certificate-attribute:: 
+The name of LDAP attribute, where will be certificate stored.
+
+swarm.elytron.ldap-key-stores._KEY_.certificate-chain-attribute:: 
+The name of LDAP attribute, where will be certificate chain stored.
+
+swarm.elytron.ldap-key-stores._KEY_.certificate-chain-encoding:: 
+The encoding of the certificate chain.
+
+swarm.elytron.ldap-key-stores._KEY_.certificate-type:: 
+The type of the Certificate.
+
+swarm.elytron.ldap-key-stores._KEY_.dir-context:: 
+The name of DirContext, which will be used to communication with LDAP server.
+
+swarm.elytron.ldap-key-stores._KEY_.filter-alias:: 
+The LDAP filter for obtaining an item of the KeyStore by alias. If this is not specified then the default value will be (alias_attribute={0}). The string '{0}' will be replaced by the searched alias and the 'alias_attribute' value will be the value of the attribute 'alias-attribute'.
+
+swarm.elytron.ldap-key-stores._KEY_.filter-certificate:: 
+The LDAP filter for obtaining an item of the KeyStore by certificate. If this is not specified then the default value will be (certificate_attribute={0}). The string '{0}' will be replaced by searched encoded certificate and the 'certificate_attribute' will be the value of the attribute 'certificate-attribute'.
+
+swarm.elytron.ldap-key-stores._KEY_.filter-iterate:: 
+The LDAP filter for iterating over all items of the KeyStore. If this is not specified then the default value will be (alias_attribute=*). The 'alias_attribute' will be the value of the attribute 'alias-attribute'.
+
+swarm.elytron.ldap-key-stores._KEY_.key-attribute:: 
+The name of LDAP attribute, where will be key stored.
+
+swarm.elytron.ldap-key-stores._KEY_.key-type:: 
+The type of KeyStore, in which will be key serialized to LDAP attribute.
+
+swarm.elytron.ldap-key-stores._KEY_.new-item-template:: 
+Configuration for item creation. Define how will look LDAP entry of newly created keystore item.
+
+swarm.elytron.ldap-key-stores._KEY_.search-path:: 
+The path in LDAP, where will be KeyStore items searched.
+
+swarm.elytron.ldap-key-stores._KEY_.search-recursive:: 
+If the LDAP search should be recursive.
+
+swarm.elytron.ldap-key-stores._KEY_.search-time-limit:: 
+The time limit for obtaining keystore items from LDAP.
+
+swarm.elytron.ldap-key-stores._KEY_.size:: 
+The size of LDAP KeyStore in amount of items/aliases.
+
+swarm.elytron.ldap-key-stores._KEY_.state:: 
+The state of the underlying service that represents this KeyStore at runtime, if it is anything other than UP runtime operations will not be available.
+
+swarm.elytron.ldap-realms._KEY_.allow-blank-password:: 
+Does this realm support blank password direct verification? Blank password attempt will be rejected otherwise.
+
+swarm.elytron.ldap-realms._KEY_.dir-context:: 
+The configuration to connect to a LDAP server.
+
+swarm.elytron.ldap-realms._KEY_.direct-verification:: 
+Does this realm support verification of credentials by directly connecting to LDAP as the account being authenticated?
+
+swarm.elytron.ldap-realms._KEY_.identity-mapping:: 
+The configuration options that define how principals are mapped to their corresponding entries in the underlying LDAP server.
+
+swarm.elytron.logical-permission-mappers._KEY_.left:: 
+Reference to the permission mapper to use to the left of the operation.
+
+swarm.elytron.logical-permission-mappers._KEY_.logical-operation:: 
+The logical operation to use to combine the permission mappers.
+
+swarm.elytron.logical-permission-mappers._KEY_.right:: 
+Reference to the permission mapper to use to the right of the operation.
+
+swarm.elytron.logical-role-mappers._KEY_.left:: 
+Reference to a role mapper to be used on the left side of the operation.
+
+swarm.elytron.logical-role-mappers._KEY_.logical-operation:: 
+The logical operation to be performed on the role mapper mappings.
+
+swarm.elytron.logical-role-mappers._KEY_.right:: 
+Reference to a role mapper to be used on the right side of the operation.
+
+swarm.elytron.mapped-regex-realm-mappers._KEY_.delegate-realm-mapper:: 
+The RealmMapper to delegate to if the pattern does not match. If no delegate is specified then the default realm on the domain will be used instead. If the username does not match the pattern and a delegate realm-mapper is present, the result of delegate-realm-mapper is mapped via the realm-map.
+
+swarm.elytron.mapped-regex-realm-mappers._KEY_.pattern:: 
+The regular expression which must contain at least one capture group to extract the realm from the name. If the regular expression matches more than one capture group, the first capture group is used.
+
+swarm.elytron.mapped-regex-realm-mappers._KEY_.realm-map:: 
+Mapping of realm name extracted using the regular expression to a defined realm name. If the value for the mapping is not in the map or the realm whose name is the result of the mapping does not exist in the given security domain, the default realm is used.
+
+swarm.elytron.mechanism-provider-filtering-sasl-server-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this factory after all filtering has been applied.
+
+swarm.elytron.mechanism-provider-filtering-sasl-server-factories._KEY_.enabling:: 
+When set to 'true' no provider loaded mechanisms are enabled unless matched by one of the filters, setting to 'false' has the inverse effect.
+
+swarm.elytron.mechanism-provider-filtering-sasl-server-factories._KEY_.filters:: 
+The filters to apply when comparing the mechanisms from the providers, a filter matches when all of the specified values match the mechanism / provider pair.
+
+swarm.elytron.mechanism-provider-filtering-sasl-server-factories._KEY_.sasl-server-factory:: 
+Reference to a sasl server factory to be wrapped by this definition.
+
+swarm.elytron.periodic-rotating-file-audit-logs._KEY_.attribute-synchronized:: 
+Whether every event should be immediately synchronised to disk.
+
+swarm.elytron.periodic-rotating-file-audit-logs._KEY_.format:: 
+The format to use to record the audit event.
+
+swarm.elytron.periodic-rotating-file-audit-logs._KEY_.path:: 
+Path of the file to be written.
+
+swarm.elytron.periodic-rotating-file-audit-logs._KEY_.relative-to:: 
+The relative path to the audit log.
+
+swarm.elytron.periodic-rotating-file-audit-logs._KEY_.suffix:: 
+The suffix string in a format which can be understood by java.time.format.DateTimeFormatter. The period of the rotation is automatically calculated based on the suffix.
+
+swarm.elytron.policies._KEY_.custom-policy:: 
+A custom policy provider definition.
+
+swarm.elytron.policies._KEY_.jacc-policy:: 
+A policy provider definition that sets up JACC and related services.
+
+swarm.elytron.properties-realms._KEY_.attribute-synchronized:: 
+The time the properties files that back this realm were last loaded.
+
+swarm.elytron.properties-realms._KEY_.groups-attribute:: 
+The name of the attribute in the returned AuthorizationIdentity that should contain the group membership information for the identity.
+
+swarm.elytron.properties-realms._KEY_.groups-properties:: 
+The properties file containing the users and their groups.
+
+swarm.elytron.properties-realms._KEY_.users-properties:: 
+The properties file containing the users and their passwords.
+
+swarm.elytron.provider-http-server-mechanism-factories._KEY_.available-mechanisms:: 
+The HTTP mechanisms available from this factory instance.
+
+swarm.elytron.provider-http-server-mechanism-factories._KEY_.providers:: 
+The providers to use to locate the factories, if not specified the globally registered list of Providers will be used.
+
+swarm.elytron.provider-loaders._KEY_.argument:: 
+An argument to be passed into the constructor as the Provider is instantiated.
+
+swarm.elytron.provider-loaders._KEY_.class-names:: 
+The fully qualified class names of the providers to load, these are loaded after the service-loader discovered providers and duplicates will be skipped.
+
+swarm.elytron.provider-loaders._KEY_.configuration:: 
+The key/value configuration to be passed to the Provider to initialise it.
+
+swarm.elytron.provider-loaders._KEY_.loaded-providers:: 
+The list of providers loaded by this provider loader.
+
+swarm.elytron.provider-loaders._KEY_.module:: 
+The name of the module to load the provider from.
+
+swarm.elytron.provider-loaders._KEY_.path:: 
+The path of the file to use to initialise the providers.
+
+swarm.elytron.provider-loaders._KEY_.relative-to:: 
+The base path of the configuration file.
+
+swarm.elytron.provider-sasl-server-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this factory after all filtering has been applied.
+
+swarm.elytron.provider-sasl-server-factories._KEY_.providers:: 
+The providers to use to locate the factories, if not specified the globally registered list of Providers will be used.
+
+swarm.elytron.regex-principal-transformers._KEY_.pattern:: 
+The regular expression to use to locate the portion of the name to be replaced.
+
+swarm.elytron.regex-principal-transformers._KEY_.replace-all:: 
+Should all occurrences of the pattern matched be replaced or only the first occurrence.
+
+swarm.elytron.regex-principal-transformers._KEY_.replacement:: 
+The value to be used as the replacement.
+
+swarm.elytron.regex-validating-principal-transformers._KEY_.match:: 
+If set to true, the name must match the given pattern to make validation successful. If set to false, the name must not match the given pattern to make validation successful.
+
+swarm.elytron.regex-validating-principal-transformers._KEY_.pattern:: 
+The regular expression to use for the principal transformer.
+
+swarm.elytron.sasl-authentication-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this configuration after all filtering has been applied.
+
+swarm.elytron.sasl-authentication-factories._KEY_.mechanism-configurations:: 
+Mechanism specific configuration
+
+swarm.elytron.sasl-authentication-factories._KEY_.sasl-server-factory:: 
+The SaslServerFactory to associate with this resource
+
+swarm.elytron.sasl-authentication-factories._KEY_.security-domain:: 
+The SecurityDomain to associate with this resource
+
+swarm.elytron.security-domains._KEY_.default-realm:: 
+The default realm contained by this security domain.
+
+swarm.elytron.security-domains._KEY_.outflow-anonymous:: 
+When outflowing to a security domain if outflow is not possible should the anonymous identity be used?  Outflowing anonymous has the effect of clearing any identity already established for that domain.
+
+swarm.elytron.security-domains._KEY_.outflow-security-domains:: 
+The list of security domains that the security identity from this domain should automatically outflow to.
+
+swarm.elytron.security-domains._KEY_.permission-mapper:: 
+A reference to a PermissionMapper to be used by this domain.
+
+swarm.elytron.security-domains._KEY_.post-realm-principal-transformer:: 
+A reference to a principal transformer to be applied after the realm has operated on the supplied identity name.
+
+swarm.elytron.security-domains._KEY_.pre-realm-principal-transformer:: 
+A reference to a principal transformer to be applied before the realm is selected.
+
+swarm.elytron.security-domains._KEY_.principal-decoder:: 
+A reference to a PrincipalDecoder to be used by this domain.
+
+swarm.elytron.security-domains._KEY_.realm-mapper:: 
+Reference to the RealmMapper to be used by this domain.
+
+swarm.elytron.security-domains._KEY_.realms:: 
+The list of realms contained by this security domain.
+
+swarm.elytron.security-domains._KEY_.role-mapper:: 
+Reference to the RoleMapper to be used by this domain.
+
+swarm.elytron.security-domains._KEY_.security-event-listener:: 
+Reference to a listener for security events.
+
+swarm.elytron.security-domains._KEY_.trusted-security-domains:: 
+The list of security domains that are trusted by this security domain.
+
+swarm.elytron.security-properties:: 
+Security properties to be set.
+
+swarm.elytron.server-ssl-contexts._KEY_.active-session-count:: 
+The count of current active sessions.
+
+swarm.elytron.server-ssl-contexts._KEY_.authentication-optional:: 
+Rejecting of the client certificate by the security domain will not prevent the connection. Allows a fall through to use other authentication mechanisms (like form login) when the client certificate is rejected by security domain. Has an effect only when the security domain is set.
+
+swarm.elytron.server-ssl-contexts._KEY_.cipher-suite-filter:: 
+The filter to apply to specify the enabled cipher suites.
+
+swarm.elytron.server-ssl-contexts._KEY_.final-principal-transformer:: 
+A final principal transformer to apply for this mechanism realm.
+
+swarm.elytron.server-ssl-contexts._KEY_.key-manager:: 
+Reference to the key manager to use within the SSLContext.
+
+swarm.elytron.server-ssl-contexts._KEY_.maximum-session-cache-size:: 
+The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
+
+swarm.elytron.server-ssl-contexts._KEY_.need-client-auth:: 
+To require a client certificate on SSL handshake. Connection without trusted client certificate (see trust-manager) will be rejected.
+
+swarm.elytron.server-ssl-contexts._KEY_.post-realm-principal-transformer:: 
+A principal transformer to apply after the realm is selected.
+
+swarm.elytron.server-ssl-contexts._KEY_.pre-realm-principal-transformer:: 
+A principal transformer to apply before the realm is selected.
+
+swarm.elytron.server-ssl-contexts._KEY_.protocols:: 
+The enabled protocols.
+
+swarm.elytron.server-ssl-contexts._KEY_.provider-name:: 
+The name of the provider to use. If not specified, all providers from providers will be passed to the SSLContext.
+
+swarm.elytron.server-ssl-contexts._KEY_.providers:: 
+The name of the providers to obtain the Provider[] to use to load the SSLContext.
+
+swarm.elytron.server-ssl-contexts._KEY_.realm-mapper:: 
+The realm mapper to be used for SSL authentication.
+
+swarm.elytron.server-ssl-contexts._KEY_.security-domain:: 
+The security domain to use for authentication during SSL session establishment.
+
+swarm.elytron.server-ssl-contexts._KEY_.session-timeout:: 
+The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.application-buffer-size:: 
+The application buffer size as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.cipher-suite:: 
+The selected cipher suite as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.creation-time:: 
+The creation time as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.last-accessed-time:: 
+The last accessed time as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.local-certificates:: 
+The local certificates from the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.local-principal:: 
+The local principal as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.packet-buffer-size:: 
+The packet buffer size as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-certificates:: 
+The peer certificates from the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-host:: 
+The peer host as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-port:: 
+The peer port as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.peer-principal:: 
+The peer principal as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.protocol:: 
+The protocol as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.ssl-sessions._KEY_.valid:: 
+The validity of the session as reported by the SSLSession.
+
+swarm.elytron.server-ssl-contexts._KEY_.trust-manager:: 
+Reference to the trust manager to use within the SSLContext.
+
+swarm.elytron.server-ssl-contexts._KEY_.use-cipher-suites-order:: 
+To honor local cipher suites preference.
+
+swarm.elytron.server-ssl-contexts._KEY_.want-client-auth:: 
+To request (but not to require) a client certificate on SSL handshake. If a security domain is referenced and supports X509 evidence, this will be set to true automatically. Ignored when need-client-auth is set.
+
+swarm.elytron.server-ssl-contexts._KEY_.wrap:: 
+Should the SSLEngine, SSLSocket, and SSLServerSocket instances returned be wrapped to protect against further modification.
+
+swarm.elytron.service-loader-http-server-mechanism-factories._KEY_.available-mechanisms:: 
+The HTTP mechanisms available from this factory instance.
+
+swarm.elytron.service-loader-http-server-mechanism-factories._KEY_.module:: 
+The module to use to obtain the classloader to load the factories, if not specified the classloader to load the resource will be used instead.
+
+swarm.elytron.service-loader-sasl-server-factories._KEY_.available-mechanisms:: 
+The SASL mechanisms available from this factory after all filtering has been applied.
+
+swarm.elytron.service-loader-sasl-server-factories._KEY_.module:: 
+The module to use to obtain the classloader to load the factories, if not specified the classloader to load the resource will be used instead.
+
+swarm.elytron.simple-permission-mappers._KEY_.mapping-mode:: 
+The mapping mode that should be used in the event of multiple matches.
+
+swarm.elytron.simple-permission-mappers._KEY_.permission-mappings:: 
+The defined permission mappings.
+
+swarm.elytron.simple-regex-realm-mappers._KEY_.delegate-realm-mapper:: 
+The RealmMapper to delegate to if there is no match using the pattern.
+
+swarm.elytron.simple-regex-realm-mappers._KEY_.pattern:: 
+The regular expression which must contain at least one capture group to extract the realm from the name. If the regular expression matches more than one capture group, the first capture group is used.
+
+swarm.elytron.simple-role-decoders._KEY_.attribute:: 
+The name of the attribute from the identity to map directly to roles.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.attribute-synchronized:: 
+Whether every event should be immediately synchronised to disk.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.format:: 
+The format to use to record the audit event.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.max-backup-index:: 
+The maximum number of files to backup when rotating.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.path:: 
+Path of the file to be written.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.relative-to:: 
+The relative path to the audit log.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.rotate-on-boot:: 
+Whether the file should be rotated before the a new file is set.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.rotate-size:: 
+The log file size the file should rotate at.
+
+swarm.elytron.size-rotating-file-audit-logs._KEY_.suffix:: 
+Format of date used as suffix of log file names in java.time.format.DateTimeFormatter. The suffix does not play a role in determining when the file should be rotated.
+
+swarm.elytron.syslog-audit-logs._KEY_.format:: 
+The format to use to record the audit event.
+
+swarm.elytron.syslog-audit-logs._KEY_.host-name:: 
+The host name to embed withing all events sent to the remote syslog server.
+
+swarm.elytron.syslog-audit-logs._KEY_.port:: 
+The listening port on the syslog server.
+
+swarm.elytron.syslog-audit-logs._KEY_.server-address:: 
+The server address of the syslog server the events should be sent to.
+
+swarm.elytron.syslog-audit-logs._KEY_.ssl-context:: 
+The SSLContext to use to connect to the syslog server when SSL_TCP transport is used.
+
+swarm.elytron.syslog-audit-logs._KEY_.transport:: 
+The transport to use to connect to the syslog server.
+
+swarm.elytron.token-realms._KEY_.jwt:: 
+A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
+
+swarm.elytron.token-realms._KEY_.oauth2-introspection:: 
+A token validator to be used in conjunction with a token-based realm that handles OAuth2 Access Tokens and validates them using an endpoint compliant with OAuth2 Token Introspection specification(RFC-7662).
+
+swarm.elytron.token-realms._KEY_.principal-claim:: 
+The name of the claim that should be used to obtain the principal's name.
+
+swarm.elytron.trust-managers._KEY_.algorithm:: 
+The name of the algorithm to use to create the underlying TrustManagerFactory.
+
+swarm.elytron.trust-managers._KEY_.alias-filter:: 
+A filter to apply to the aliases returned from the KeyStore, can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+
+swarm.elytron.trust-managers._KEY_.certificate-revocation-list:: 
+Enables certificate revocation list checks to a trust manager.
+
+swarm.elytron.trust-managers._KEY_.key-store:: 
+Reference to the KeyStore to use to initialise the underlying TrustManagerFactory.
+
+swarm.elytron.trust-managers._KEY_.provider-name:: 
+The name of the provider to use to create the underlying TrustManagerFactory.
+
+swarm.elytron.trust-managers._KEY_.providers:: 
+Reference to obtain the Provider[] to use when creating the underlying TrustManagerFactory.
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.attribute-name:: 
+The name of the X.500 attribute to map (can be defined using OID instead)
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.convert:: 
+When set to 'true', if the Principal is not already an X500Principal conversion will be attempted
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.joiner:: 
+The joining string
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.maximum-segments:: 
+The maximum number of occurrences of the attribute to map
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.oid:: 
+The OID of the X.500 attribute to map (can be defined using attribute name instead)
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.required-attributes:: 
+The attributes names of the attributes that must be present in the principal
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.required-oids:: 
+The OIDs of the attributes that must be present in the principal
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.reverse:: 
+When set to 'true', the attribute values will be processed and returned in reverse order
+
+swarm.elytron.x500-attribute-principal-decoders._KEY_.start-segment:: 
+The 0-based starting occurrence of the attribute to map
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/hibernate-validator.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/hibernate-validator.adoc
@@ -1,4 +1,4 @@
-# Hibernate Validator
+= Hibernate Validator
 
 Provides support and integration for applications using Hibernate Validator.
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/hystrix.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/hystrix.adoc
@@ -1,0 +1,120 @@
+= Hystrix
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>hystrix</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.hystrix.collapser.default.maxRequestsInBatch:: 
+The maximum number of requests allowed in a batch before this triggers a batch execution
+
+swarm.hystrix.collapser.default.requestCache.enabled:: 
+Indicates whether request caching is enabled for HystrixCollapser.execute() and HystrixCollapser.queue() invocations
+
+swarm.hystrix.collapser.default.timerDelayInMilliseconds:: 
+The number of milliseconds after the creation of the batch that its execution is triggered
+
+swarm.hystrix.command.default.circuitBreaker.enabled:: 
+Determines whether a circuit breaker will be used to track health and to short-circuit requests if it trips
+
+swarm.hystrix.command.default.circuitBreaker.errorThresholdPercentage:: 
+The error percentage at or above which the circuit should trip open and start short-circuiting requests to fallback logic
+
+swarm.hystrix.command.default.circuitBreaker.forceClosed:: 
+If true, forces the circuit breaker into a closed state in which it will allow requests regardless of the error percentage
+
+swarm.hystrix.command.default.circuitBreaker.forceOpen:: 
+If true, forces the circuit breaker into an open (tripped) state in which it will reject all requests
+
+swarm.hystrix.command.default.circuitBreaker.requestVolumeThreshold:: 
+The minimum number of requests in a rolling window that will trip the circuit
+
+swarm.hystrix.command.default.circuitBreaker.sleepWindowInMilliseconds:: 
+The amount of time, after tripping the circuit, to reject requests before allowing attempts again to determine if the circuit should again be closed
+
+swarm.hystrix.command.default.execution.isolation.semaphore.maxConcurrentRequests:: 
+The maximum number of requests allowed to a HystrixCommand.run() method when you are using ExecutionIsolationStrategy.SEMAPHORE
+
+swarm.hystrix.command.default.execution.isolation.strategy:: 
+Isolation strategy (THREAD or SEMAPHORE)
+
+swarm.hystrix.command.default.execution.isolation.thread.interruptOnCancel:: 
+Indicates whether the HystrixCommand.run() execution should be interrupted when a cancellation occurs
+
+swarm.hystrix.command.default.execution.isolation.thread.interruptOnTimeout:: 
+Indicates whether the HystrixCommand.run() execution should be interrupted when a timeout occurs
+
+swarm.hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:: 
+The time in milliseconds after which the caller will observe a timeout and walk away from the command execution
+
+swarm.hystrix.command.default.execution.timeout.enabled:: 
+Indicates whether the HystrixCommand.run() execution should have a timeout
+
+swarm.hystrix.command.default.fallback.enabled:: 
+Determines whether a call to HystrixCommand.getFallback() will be attempted when failure or rejection occurs
+
+swarm.hystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests:: 
+The maximum number of requests allowed to a HystrixCommand.getFallback() method when you are using ExecutionIsolationStrategy.SEMAPHORE
+
+swarm.hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds:: 
+The time to wait, in milliseconds, between allowing health snapshots to be taken that calculate success and error percentages and affect circuit breaker status
+
+swarm.hystrix.command.default.metrics.rollingPercentile.bucketSize:: 
+The maximum number of execution times that are kept per bucket
+
+swarm.hystrix.command.default.metrics.rollingPercentile.enabled:: 
+Indicates whether execution latencies should be tracked and calculated as percentiles
+
+swarm.hystrix.command.default.metrics.rollingPercentile.numBuckets:: 
+The number of buckets the rollingPercentile window will be divided into
+
+swarm.hystrix.command.default.metrics.rollingPercentile.timeInMilliseconds:: 
+The duration of the rolling window in which execution times are kept to allow for percentile calculations, in milliseconds
+
+swarm.hystrix.command.default.metrics.rollingStats.numBuckets:: 
+The number of buckets the rolling statistical window is divided into
+
+swarm.hystrix.command.default.metrics.rollingStats.timeInMilliseconds:: 
+The duration of the statistical rolling window, in milliseconds. This is how long Hystrix keeps metrics for the circuit breaker to use and for publishing
+
+swarm.hystrix.command.default.requestCache.enabled:: 
+Indicates whether HystrixCommand.getCacheKey() should be used with HystrixRequestCache to provide de-duplication functionality via request-scoped caching
+
+swarm.hystrix.command.default.requestLog.enabled:: 
+Indicates whether HystrixCommand execution and events should be logged to HystrixRequestLog
+
+swarm.hystrix.stream.path:: 
+Context path for the stream
+
+swarm.hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize:: 
+Allows the configuration for maximumSize to take effect
+
+swarm.hystrix.threadpool.default.coreSize:: 
+The core thread-pool size
+
+swarm.hystrix.threadpool.default.keepAliveTimeMinutes:: 
+The keep-alive time, in minutes
+
+swarm.hystrix.threadpool.default.maxQueueSize:: 
+The maximum queue size of the BlockingQueue implementation
+
+swarm.hystrix.threadpool.default.maximumSize:: 
+The maximum thread-pool size
+
+swarm.hystrix.threadpool.default.metrics.rollingPercentile.numBuckets:: 
+The number of buckets the rolling statistical window is divided into
+
+swarm.hystrix.threadpool.default.metrics.rollingStats.timeInMilliseconds:: 
+The duration of the statistical rolling window, in milliseconds
+
+swarm.hystrix.threadpool.default.queueSizeRejectionThreshold:: 
+The queue size rejection threshold - an artificial maximum queue size at which rejections will occur even if maxQueueSize has not been reached
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/io.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/io.adoc
@@ -1,4 +1,4 @@
-# IO
+= IO
 
 Primarily an internal fraction supporting I/O activities
 for higher-level fractions.
@@ -24,8 +24,41 @@ How many buffers per slice, if not set optimal value is calculated based on avai
 swarm.io.buffer-pools._KEY_.direct-buffers:: 
 Does the buffer pool use direct buffers, some platforms don't support direct buffers
 
+swarm.io.workers._KEY_.core-pool-size:: 
+Minimum number of threads to keep in the underlying java.util.concurrent.ThreadPoolExecutor even if they are idle. Threads over this limit will be terminated over time specified by task-keepalive attribute.
+
+swarm.io.workers._KEY_.io-thread-count:: 
+I/O thread count
+
 swarm.io.workers._KEY_.io-threads:: 
 Specify the number of I/O threads to create for the worker.  If not specified, a default will be chosen, which is calculated by cpuCount * 2
+
+swarm.io.workers._KEY_.max-pool-size:: 
+The maximum number of threads to allow in the thread pool. Depending on implementation, when this limit is reached, tasks which cannot be queued may be rejected.
+
+swarm.io.workers._KEY_.outbound-bind-address._KEY_.bind-address:: 
+The address to bind to when the destination address matches
+
+swarm.io.workers._KEY_.outbound-bind-address._KEY_.bind-port:: 
+The port number to bind to when the destination address matches
+
+swarm.io.workers._KEY_.outbound-bind-address._KEY_.match:: 
+The destination address range to match
+
+swarm.io.workers._KEY_.queue-size:: 
+An estimate of the number of tasks in the worker queue.
+
+swarm.io.workers._KEY_.servers._KEY_.connection-count:: 
+Estimate of the current connection count
+
+swarm.io.workers._KEY_.servers._KEY_.connection-limit-high-water-mark:: 
+If the connection count hits this number, no new connections will be accepted until the count drops below the low-water mark.
+
+swarm.io.workers._KEY_.servers._KEY_.connection-limit-low-water-mark:: 
+If the connection count has previously hit the high water mark, once it drops back down below this count, connections will be accepted again.
+
+swarm.io.workers._KEY_.shutdown-requested:: 
+True is shutdown of the pool was requested
 
 swarm.io.workers._KEY_.stack-size:: 
 The stack size (in bytes) to attempt to use for worker threads.
@@ -34,6 +67,6 @@ swarm.io.workers._KEY_.task-keepalive::
 Specify the number of milliseconds to keep non-core task threads alive.
 
 swarm.io.workers._KEY_.task-max-threads:: 
-Specify the maximum number of threads for the worker task thread pool.If not set, default value used which is calculated by formula cpuCount * 16
+Specify the maximum number of threads for the worker task thread pool.If not set, default value used which is calculated by formula cpuCount * 16,as long as MaxFileDescriptorCount jmx property allows that number, otherwise calculation takes max into account to adjust it accordingly.
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaeger.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaeger.adoc
@@ -1,0 +1,48 @@
+= Jaeger
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>jaeger</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.jaeger.agent-host:: 
+The hostname for communicating with agent via UDP
+
+swarm.jaeger.agent-port:: 
+The port for communicating with agent via UDP
+
+swarm.jaeger.enable-b3-header-propagation:: 
+Whether to enable propagation of B3 headers in the configured Tracer. By default this is false.
+
+swarm.jaeger.remote-reporter-http-endpoint:: 
+Remote Reporter HTTP endpoint for Jaeger collector, such as http://jaeger-collector.istio-system:14268/api/traces
+
+swarm.jaeger.reporter-flush-interval:: 
+The reporter's flush interval (ms)
+
+swarm.jaeger.reporter-log-spans:: 
+Whether the reporter should also log the spans
+
+swarm.jaeger.reporter-max-queue-size:: 
+The reporter's maximum queue size
+
+swarm.jaeger.sampler-manager-host:: 
+The host name and port when using the remote controlled sampler
+
+swarm.jaeger.sampler-parameter:: 
+The sampler parameter (number). Ex.: `1`
+
+swarm.jaeger.sampler-type:: 
+The sampler type. Ex.: `const`
+
+swarm.jaeger.service-name:: 
+The service name. Required (via this parameter, system property or env var). Ex.: `order-manager`
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-cdi.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-cdi.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + CDI
+= JAX-RS + CDI
 
 An internal fraction providing integration between JAX-RS
 and CDI.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-jaxb.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-jaxb.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + JAXB
+= JAX-RS + JAXB
 
 Provides support within JAX-RS applications for the XML binding
 framework according to JSR-31 and JSR-222.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-jsonp.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-jsonp.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + JSON-P
+= JAX-RS + JSON-P
 
 Provides support within JAX-RS application for JSON processing
 according to JSR-374.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-multipart.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-multipart.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + Multipart
+= JAX-RS + Multipart
 
 Provides support within JAX-RS application for MIME multipart
 form processing. 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-validator.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs-validator.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + Validator
+= JAX-RS + Validator
 
 Provides integration and support between JAX-RS applications and
 Hibernate Validator.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jaxrs.adoc
@@ -1,4 +1,4 @@
-# JAX-RS
+= JAX-RS
 
 Provides support for building RESTful web services according to JSR-311.
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jca.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jca.adoc
@@ -1,4 +1,4 @@
-# JCA
+= JCA
 
 Provides support for the Java Connector Architecture (JCA)
 according to JSR 322.
@@ -44,6 +44,9 @@ Do not cache unknown connections
 
 swarm.jca.cached-connection-manager.install:: 
 Enable/disable the cached connection manager valve and interceptor
+
+swarm.jca.distributed-workmanagers._KEY_.elytron-enabled:: 
+Enables Elytron security for this workmanager.
 
 swarm.jca.distributed-workmanagers._KEY_.long-running-threads._KEY_.allow-core-timeout:: 
 Whether core threads may time out.
@@ -134,6 +137,9 @@ Specifies the name of a specific thread factory to use to create worker threads.
 
 swarm.jca.tracer.enabled:: 
 Specify whether tracer is enabled
+
+swarm.jca.workmanagers._KEY_.elytron-enabled:: 
+Enables Elytron security for this workmanager.
 
 swarm.jca.workmanagers._KEY_.long-running-threads._KEY_.allow-core-timeout:: 
 Whether core threads may time out.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jmx.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jmx.adoc
@@ -1,4 +1,4 @@
-# JMX
+= JMX
 
 Provides support for Java Management Extensions (JMX)
 according to JSR-3.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jpa.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jpa.adoc
@@ -1,4 +1,4 @@
-# JPA
+= JPA
 
 Provides support for the Java Persistence API according
 to JSR-220.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/jsf.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/jsf.adoc
@@ -1,4 +1,4 @@
-# JSF
+= JSF
 
 Provides support for JavaServer Faces according to JSR-344.
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/keycloak.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/keycloak.adoc
@@ -27,6 +27,9 @@ Base URL of the Realm Auth Server
 swarm.keycloak.realms._KEY_.auth-server-url-for-backend-requests:: 
 URL to use to make background calls to auth server
 
+swarm.keycloak.realms._KEY_.autodetect-bearer-only:: 
+autodetect bearer-only requests
+
 swarm.keycloak.realms._KEY_.client-key-password:: 
 n/a
 
@@ -36,6 +39,9 @@ n/a
 swarm.keycloak.realms._KEY_.client-keystore-password:: 
 n/a
 
+swarm.keycloak.realms._KEY_.confidential-port:: 
+Specify the confidential port (SSL/TLS) used by the Realm Auth Server
+
 swarm.keycloak.realms._KEY_.connection-pool-size:: 
 Connection pool size for the client used by the adapter
 
@@ -44,6 +50,9 @@ CORS allowed headers
 
 swarm.keycloak.realms._KEY_.cors-allowed-methods:: 
 CORS allowed methods
+
+swarm.keycloak.realms._KEY_.cors-exposed-headers:: 
+CORS exposed headers
 
 swarm.keycloak.realms._KEY_.cors-max-age:: 
 CORS max-age header
@@ -56,6 +65,9 @@ Enable Keycloak CORS support
 
 swarm.keycloak.realms._KEY_.expose-token:: 
 Enable secure URL that exposes access token
+
+swarm.keycloak.realms._KEY_.ignore-oauth-query-parameter:: 
+disable query parameter parsing for access_token
 
 swarm.keycloak.realms._KEY_.principal-attribute:: 
 token attribute to use to set Principal name
@@ -93,6 +105,9 @@ Base URL of the Realm Auth Server
 swarm.keycloak.secure-deployments._KEY_.auth-server-url-for-backend-requests:: 
 URL to use to make background calls to auth server
 
+swarm.keycloak.secure-deployments._KEY_.autodetect-bearer-only:: 
+autodetect bearer-only requests
+
 swarm.keycloak.secure-deployments._KEY_.bearer-only:: 
 Bearer Token Auth only
 
@@ -105,6 +120,9 @@ n/a
 swarm.keycloak.secure-deployments._KEY_.client-keystore-password:: 
 n/a
 
+swarm.keycloak.secure-deployments._KEY_.confidential-port:: 
+Specify the confidential port (SSL/TLS) used by the Realm Auth Server
+
 swarm.keycloak.secure-deployments._KEY_.connection-pool-size:: 
 Connection pool size for the client used by the adapter
 
@@ -113,6 +131,9 @@ CORS allowed headers
 
 swarm.keycloak.secure-deployments._KEY_.cors-allowed-methods:: 
 CORS allowed methods
+
+swarm.keycloak.secure-deployments._KEY_.cors-exposed-headers:: 
+CORS exposed headers
 
 swarm.keycloak.secure-deployments._KEY_.cors-max-age:: 
 CORS max-age header
@@ -132,6 +153,9 @@ Enable Keycloak CORS support
 swarm.keycloak.secure-deployments._KEY_.expose-token:: 
 Enable secure URL that exposes access token
 
+swarm.keycloak.secure-deployments._KEY_.ignore-oauth-query-parameter:: 
+disable query parameter parsing for access_token
+
 swarm.keycloak.secure-deployments._KEY_.min-time-between-jwks-requests:: 
 If adapter recognize token signed by unknown public key, it will try to download new public key from keycloak server. However it won't try to download if already tried it in less than 'min-time-between-jwks-requests' seconds
 
@@ -146,6 +170,9 @@ Keycloak realm
 
 swarm.keycloak.secure-deployments._KEY_.realm-public-key:: 
 Public key of the realm
+
+swarm.keycloak.secure-deployments._KEY_.redirect-rewrite-rules._KEY_.value:: 
+redirect-rewrite-rule value
 
 swarm.keycloak.secure-deployments._KEY_.register-node-at-startup:: 
 Cluster setting
@@ -175,6 +202,117 @@ swarm.keycloak.secure-deployments._KEY_.turn-off-change-session-id-on-login::
 The session id is changed by default on a successful login.  Change this to true if you want to turn this off
 
 swarm.keycloak.secure-deployments._KEY_.use-resource-role-mappings:: 
+Use resource level permissions from token
+
+swarm.keycloak.secure-servers._KEY_.allow-any-hostname:: 
+SSL Setting
+
+swarm.keycloak.secure-servers._KEY_.always-refresh-token:: 
+Refresh token on every single web request
+
+swarm.keycloak.secure-servers._KEY_.auth-server-url:: 
+Base URL of the Realm Auth Server
+
+swarm.keycloak.secure-servers._KEY_.auth-server-url-for-backend-requests:: 
+URL to use to make background calls to auth server
+
+swarm.keycloak.secure-servers._KEY_.autodetect-bearer-only:: 
+autodetect bearer-only requests
+
+swarm.keycloak.secure-servers._KEY_.bearer-only:: 
+Bearer Token Auth only
+
+swarm.keycloak.secure-servers._KEY_.client-key-password:: 
+n/a
+
+swarm.keycloak.secure-servers._KEY_.client-keystore:: 
+n/a
+
+swarm.keycloak.secure-servers._KEY_.client-keystore-password:: 
+n/a
+
+swarm.keycloak.secure-servers._KEY_.confidential-port:: 
+Specify the confidential port (SSL/TLS) used by the Realm Auth Server
+
+swarm.keycloak.secure-servers._KEY_.connection-pool-size:: 
+Connection pool size for the client used by the adapter
+
+swarm.keycloak.secure-servers._KEY_.cors-allowed-headers:: 
+CORS allowed headers
+
+swarm.keycloak.secure-servers._KEY_.cors-allowed-methods:: 
+CORS allowed methods
+
+swarm.keycloak.secure-servers._KEY_.cors-exposed-headers:: 
+CORS exposed headers
+
+swarm.keycloak.secure-servers._KEY_.cors-max-age:: 
+CORS max-age header
+
+swarm.keycloak.secure-servers._KEY_.credentials._KEY_.value:: 
+Credential value
+
+swarm.keycloak.secure-servers._KEY_.disable-trust-manager:: 
+Adapter will not use a trust manager when making adapter HTTPS requests
+
+swarm.keycloak.secure-servers._KEY_.enable-basic-auth:: 
+Enable Basic Authentication
+
+swarm.keycloak.secure-servers._KEY_.enable-cors:: 
+Enable Keycloak CORS support
+
+swarm.keycloak.secure-servers._KEY_.expose-token:: 
+Enable secure URL that exposes access token
+
+swarm.keycloak.secure-servers._KEY_.ignore-oauth-query-parameter:: 
+disable query parameter parsing for access_token
+
+swarm.keycloak.secure-servers._KEY_.min-time-between-jwks-requests:: 
+If adapter recognize token signed by unknown public key, it will try to download new public key from keycloak server. However it won't try to download if already tried it in less than 'min-time-between-jwks-requests' seconds
+
+swarm.keycloak.secure-servers._KEY_.principal-attribute:: 
+token attribute to use to set Principal name
+
+swarm.keycloak.secure-servers._KEY_.public-client:: 
+Public client
+
+swarm.keycloak.secure-servers._KEY_.realm:: 
+Keycloak realm
+
+swarm.keycloak.secure-servers._KEY_.realm-public-key:: 
+Public key of the realm
+
+swarm.keycloak.secure-servers._KEY_.redirect-rewrite-rules._KEY_.value:: 
+redirect-rewrite-rule value
+
+swarm.keycloak.secure-servers._KEY_.register-node-at-startup:: 
+Cluster setting
+
+swarm.keycloak.secure-servers._KEY_.register-node-period:: 
+how often to re-register node
+
+swarm.keycloak.secure-servers._KEY_.resource:: 
+Application name
+
+swarm.keycloak.secure-servers._KEY_.ssl-required:: 
+Specify if SSL is required (valid values are all, external and none)
+
+swarm.keycloak.secure-servers._KEY_.token-minimum-time-to-live:: 
+The adapter will refresh the token if the current token is expired OR will expire in 'token-minimum-time-to-live' seconds or less
+
+swarm.keycloak.secure-servers._KEY_.token-store:: 
+cookie or session storage for auth session data
+
+swarm.keycloak.secure-servers._KEY_.truststore:: 
+Truststore used for adapter client HTTPS requests
+
+swarm.keycloak.secure-servers._KEY_.truststore-password:: 
+Password of the Truststore
+
+swarm.keycloak.secure-servers._KEY_.turn-off-change-session-id-on-login:: 
+The session id is changed by default on a successful login.  Change this to true if you want to turn this off
+
+swarm.keycloak.secure-servers._KEY_.use-resource-role-mappings:: 
 Use resource level permissions from token
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/logging.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/logging.adoc
@@ -1,4 +1,4 @@
-# Logging
+= Logging
 
 Provides facilities to configure logging categories, levels and handlers.
 
@@ -30,6 +30,9 @@ A filter expression value to define a filter. Example for a filter that does not
 swarm.logging.async-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this handler. Message levels lower than this value will be discarded.
 
+swarm.logging.async-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.async-handlers._KEY_.overflow-action:: 
 Specify what action to take when the overflowing.  The valid options are 'block' and 'discard'
 
@@ -56,6 +59,9 @@ Defines a pattern for the formatter.
 
 swarm.logging.console-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
+
+swarm.logging.console-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.console-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -93,6 +99,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 swarm.logging.custom-handlers._KEY_.module:: 
 The module that the logging handler depends on.
 
+swarm.logging.custom-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.custom-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
 
@@ -123,6 +132,9 @@ Defines a pattern for the formatter.
 swarm.logging.file-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
 
+swarm.logging.file-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
 
@@ -151,7 +163,7 @@ swarm.logging.loggers._KEY_.level::
 The log level specifying which message levels will be logged by the logger. Message levels lower than this value will be discarded.
 
 swarm.logging.loggers._KEY_.use-parent-handlers:: 
-Specifies whether or not this logger should send its output to it's parent Logger.
+Specifies whether or not this logger should send its output to its parent Logger.
 
 swarm.logging.logging-profiles._KEY_.async-handlers._KEY_.enabled:: 
 If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.
@@ -161,6 +173,9 @@ A filter expression value to define a filter. Example for a filter that does not
 
 swarm.logging.logging-profiles._KEY_.async-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this handler. Message levels lower than this value will be discarded.
+
+swarm.logging.logging-profiles._KEY_.async-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.logging-profiles._KEY_.async-handlers._KEY_.overflow-action:: 
 Specify what action to take when the overflowing.  The valid options are 'block' and 'discard'
@@ -188,6 +203,9 @@ Defines a pattern for the formatter.
 
 swarm.logging.logging-profiles._KEY_.console-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
+
+swarm.logging.logging-profiles._KEY_.console-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.logging-profiles._KEY_.console-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -225,6 +243,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 swarm.logging.logging-profiles._KEY_.custom-handlers._KEY_.module:: 
 The module that the logging handler depends on.
 
+swarm.logging.logging-profiles._KEY_.custom-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.logging-profiles._KEY_.custom-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
 
@@ -255,6 +276,9 @@ Defines a pattern for the formatter.
 swarm.logging.logging-profiles._KEY_.file-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
 
+swarm.logging.logging-profiles._KEY_.file-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.logging-profiles._KEY_.file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
 
@@ -283,7 +307,7 @@ swarm.logging.logging-profiles._KEY_.loggers._KEY_.level::
 The log level specifying which message levels will be logged by the logger. Message levels lower than this value will be discarded.
 
 swarm.logging.logging-profiles._KEY_.loggers._KEY_.use-parent-handlers:: 
-Specifies whether or not this logger should send its output to it's parent Logger.
+Specifies whether or not this logger should send its output to its parent Logger.
 
 swarm.logging.logging-profiles._KEY_.pattern-formatters._KEY_.color-map:: 
 The color-map attribute allows for a comma delimited list of colors to be used for different levels with a pattern formatter. The format for the color mapping pattern is level-name:color-name.Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen, brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
@@ -314,6 +338,9 @@ Defines a pattern for the formatter.
 
 swarm.logging.logging-profiles._KEY_.periodic-rotating-file-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
+
+swarm.logging.logging-profiles._KEY_.periodic-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.logging-profiles._KEY_.periodic-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -347,6 +374,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 
 swarm.logging.logging-profiles._KEY_.periodic-size-rotating-file-handlers._KEY_.max-backup-index:: 
 The maximum number of backups to keep.
+
+swarm.logging.logging-profiles._KEY_.periodic-size-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.logging-profiles._KEY_.periodic-size-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -395,6 +425,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 
 swarm.logging.logging-profiles._KEY_.size-rotating-file-handlers._KEY_.max-backup-index:: 
 The maximum number of backups to keep.
+
+swarm.logging.logging-profiles._KEY_.size-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.logging-profiles._KEY_.size-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -462,6 +495,9 @@ Defines a pattern for the formatter.
 swarm.logging.periodic-rotating-file-handlers._KEY_.level:: 
 The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
 
+swarm.logging.periodic-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
+
 swarm.logging.periodic-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
 
@@ -494,6 +530,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 
 swarm.logging.periodic-size-rotating-file-handlers._KEY_.max-backup-index:: 
 The maximum number of backups to keep.
+
+swarm.logging.periodic-size-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.periodic-size-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.
@@ -542,6 +581,9 @@ The log level specifying which message levels will be logged by this logger. Mes
 
 swarm.logging.size-rotating-file-handlers._KEY_.max-backup-index:: 
 The maximum number of backups to keep.
+
+swarm.logging.size-rotating-file-handlers._KEY_.name:: 
+The name of the handler.
 
 swarm.logging.size-rotating-file-handlers._KEY_.named-formatter:: 
 The name of the defined formatter to be used on the handler.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/management.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/management.adoc
@@ -1,6 +1,6 @@
-# Management
+= Management
 
-Provides the WildFly management API.
+Provides the {WildFly} management API.
 
 
 .Maven Coordinates
@@ -41,6 +41,9 @@ The path of the audit log file.
 swarm.management.audit-access.file-handlers._KEY_.relative-to:: 
 The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
 
+swarm.management.audit-access.file-handlers._KEY_.rotate-at-startup:: 
+Whether the old log file should be rotated at server startup.
+
 swarm.management.audit-access.in-memory-handlers._KEY_.max-history:: 
 The maximum number of operation stored in history for this handler.
 
@@ -48,7 +51,7 @@ swarm.management.audit-access.json-formatters._KEY_.compact::
 If true will format the JSON on one line. There may still be values containing new lines, so if having the whole record on one line is important, set escape-new-line or escape-control-characters to true.
 
 swarm.management.audit-access.json-formatters._KEY_.date-format:: 
-The date format to use as understood by {@link java.text.SimpleDateFormat}. Will be ignored if include-date="false".
+The date format to use as understood by java.text.SimpleDateFormat. Will be ignored if include-date="false".
 
 swarm.management.audit-access.json-formatters._KEY_.date-separator:: 
 The separator between the date and the rest of the formatted log message. Will be ignored if include-date="false".
@@ -147,11 +150,17 @@ If a connection drop is detected, the number of seconds to wait before reconnect
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.key-password:: 
 The password for the keystore key.
 
+swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.key-password-credential-reference:: 
+The reference to credential for the keystore key stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.keystore-password:: 
 The password for the keystore.
 
+swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.keystore-password-credential-reference:: 
+The reference to credential for the keystore password stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.keystore-path:: 
-=The path of the keystore.
+The path of the keystore.
 
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.client-certificate-store-authentication.keystore-relative-to:: 
 The name of another previously named path, or of one of the standard paths provided by the system. If 'keystore-relative-to' is provided, the value of the 'keystore-path' attribute is treated as relative to the path specified by this attribute.
@@ -171,8 +180,11 @@ If a connection drop is detected, the number of seconds to wait before reconnect
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.truststore-authentication.keystore-password:: 
 The password for the truststore.
 
+swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.truststore-authentication.keystore-password-credential-reference:: 
+The reference to credential for the truststore password stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.truststore-authentication.keystore-path:: 
-=The path of the truststore.
+The path of the truststore.
 
 swarm.management.audit-access.syslog-handlers._KEY_.tls-protocol.truststore-authentication.keystore-relative-to:: 
 The name of another previously named path, or of one of the standard paths provided by the system. If 'keystore-relative-to' is provided, the value of the 'keystore-path' attribute is treated as relative to the path specified by this attribute.
@@ -255,6 +267,9 @@ Whether targets having this application type constraint are considered applicati
 swarm.management.authorization-access.standard-role-names:: 
 The official names of the standard roles supported by the current management access control provider.
 
+swarm.management.authorization-access.use-identity-roles:: 
+Should the raw roles obtained from the underlying security identity be used directly?
+
 swarm.management.authorization-access.vault-expression-constraint.configured-requires-read:: 
 Set to override the default as to whether reading attributes containing vault expressions should be considered sensitive.
 
@@ -279,6 +294,12 @@ Comma separated list of trusted Origins for sending Cross-Origin Resource Sharin
 swarm.management.http-interface-management-interface.console-enabled:: 
 Flag that indicates admin console is enabled
 
+swarm.management.http-interface-management-interface.http-authentication-factory:: 
+The authentication policy to use to secure the interface for normal HTTP requests.
+
+swarm.management.http-interface-management-interface.http-upgrade:: 
+HTTP Upgrade specific configuration
+
 swarm.management.http-interface-management-interface.http-upgrade-enabled:: 
 Flag that indicates HTTP Upgrade is enabled, which allows HTTP requests to be upgraded to native remoting connections
 
@@ -286,16 +307,19 @@ swarm.management.http-interface-management-interface.sasl-protocol::
 The name of the protocol to be passed to the SASL mechanisms used for authentication.
 
 swarm.management.http-interface-management-interface.secure-socket-binding:: 
-The name of the socket binding configuration to use for the HTTPS management interface's socket.
+The name of the socket binding configuration to use for the HTTPS management interface's socket.  When defined at least one of ssl-context or security-realm must also be defined.
 
 swarm.management.http-interface-management-interface.security-realm:: 
-The security realm to use for the HTTP management interface.
+The legacy security realm to use for the HTTP management interface.
 
 swarm.management.http-interface-management-interface.server-name:: 
 The name of the server used in the initial Remoting exchange and within the SASL mechanisms.
 
 swarm.management.http-interface-management-interface.socket-binding:: 
 The name of the socket binding configuration to use for the HTTP management interface's socket.
+
+swarm.management.http-interface-management-interface.ssl-context:: 
+Reference to the SSLContext to use for this management interface.
 
 swarm.management.http.disable:: 
 Flag to disable HTTP access to management interface
@@ -305,6 +329,12 @@ Port for HTTP access to management interface
 
 swarm.management.https.port:: 
 Port for HTTPS access to management interface
+
+swarm.management.identity-access.security-domain:: 
+Reference to the security domain to use to obtain the current identity performing a management request.
+
+swarm.management.ldap-connections._KEY_.always-send-client-cert:: 
+If true, the client SSL certificate will be sent to LDAP server with every request; otherwise the client SSL certificate will not be sent when verifying the user credentials
 
 swarm.management.ldap-connections._KEY_.handles-referrals-for:: 
 List of URLs that this connection handles referrals for.
@@ -320,6 +350,9 @@ The referral handling mode for this connection.
 
 swarm.management.ldap-connections._KEY_.search-credential:: 
 The credential to use when connecting to perform a search.
+
+swarm.management.ldap-connections._KEY_.search-credential-reference:: 
+The reference to the search credential stored in CredentialStore under defined alias or clear text password.
 
 swarm.management.ldap-connections._KEY_.search-dn:: 
 The distinguished name to use when connecting to the LDAP server to perform searches.
@@ -346,7 +379,7 @@ swarm.management.management-operations-service.active-operations._KEY_.domain-ro
 True if the operation is a subsidiary request on a domain process other than the one directly handling the original operation, executing locally as part of the rollout of the original operation across the domain.
 
 swarm.management.management-operations-service.active-operations._KEY_.domain-uuid:: 
-Identifier of an overall multi-process domain operation of which this operation is a part, or undefined is this operation is not associated with such a domain operation.
+Identifier of an overall multi-process domain operation of which this operation is a part, or undefined if this operation is not associated with such a domain operation.
 
 swarm.management.management-operations-service.active-operations._KEY_.exclusive-running-time:: 
 Amount of time the operation has been executing with the exclusive operation execution lock held, or -1 if the operation does not hold the exclusive execution lock.
@@ -360,17 +393,23 @@ The name of the operation, or '<hidden>' if the caller is not authorized to addr
 swarm.management.management-operations-service.active-operations._KEY_.running-time:: 
 Amount of time the operation has been executing.
 
+swarm.management.native-interface-management-interface.sasl-authentication-factory:: 
+The SASL authentication policy to use to secure this interface.
+
 swarm.management.native-interface-management-interface.sasl-protocol:: 
 The name of the protocol to be passed to the SASL mechanisms used for authentication.
 
 swarm.management.native-interface-management-interface.security-realm:: 
-The security realm to use for the native management interface.
+The legacy security realm to use for the native management interface.
 
 swarm.management.native-interface-management-interface.server-name:: 
 The name of the server used in the initial Remoting exchange and within the SASL mechanisms.
 
 swarm.management.native-interface-management-interface.socket-binding:: 
 The name of the socket binding configuration to use for the native management interface's socket.
+
+swarm.management.native-interface-management-interface.ssl-context:: 
+Reference to the SSLContext to use for this management interface.
 
 swarm.management.security-realms._KEY_.jaas-authentication.assign-groups:: 
 Map the roles loaded by JAAS to groups.
@@ -573,6 +612,9 @@ Which attribute on a group entry is it's simple name.
 swarm.management.security-realms._KEY_.ldap-authorization.principal-to-group-group-search.iterative:: 
 Should further searches be performed to identify groups that the groups identified are a member of?
 
+swarm.management.security-realms._KEY_.ldap-authorization.principal-to-group-group-search.parse-group-name-from-dn:: 
+Should the group name be extracted from the distinguished name.
+
 swarm.management.security-realms._KEY_.ldap-authorization.principal-to-group-group-search.prefer-original-connection:: 
 After following a referral should subsequent searches prefer the original connection or use the connection of the last referral.
 
@@ -687,6 +729,9 @@ The path of the properties file containing the users roles.
 swarm.management.security-realms._KEY_.properties-authorization.relative-to:: 
 The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
 
+swarm.management.security-realms._KEY_.secret-server-identity.credential-reference:: 
+The reference to credential for the secret / password stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.security-realms._KEY_.secret-server-identity.value:: 
 The secret / password - Base64 Encoded.
 
@@ -705,8 +750,14 @@ If the keystore does not exist and this attribute is set then a self signed cert
 swarm.management.security-realms._KEY_.ssl-server-identity.key-password:: 
 The password to obtain the key from the keystore.
 
+swarm.management.security-realms._KEY_.ssl-server-identity.key-password-credential-reference:: 
+The reference to credential for the keystore key stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.security-realms._KEY_.ssl-server-identity.keystore-password:: 
 The password to open the keystore.
+
+swarm.management.security-realms._KEY_.ssl-server-identity.keystore-password-credential-reference:: 
+The reference to credential for the keystore password stored in CredentialStore under defined alias or clear text password.
 
 swarm.management.security-realms._KEY_.ssl-server-identity.keystore-path:: 
 The path of the keystore, will be ignored if the keystore-provider is anything other than JKS.
@@ -723,6 +774,9 @@ The protocol to use when creating the SSLContext.
 swarm.management.security-realms._KEY_.truststore-authentication.keystore-password:: 
 The password to open the keystore.
 
+swarm.management.security-realms._KEY_.truststore-authentication.keystore-password-credential-reference:: 
+The reference to credential for the keystore password stored in CredentialStore under defined alias or clear text password.
+
 swarm.management.security-realms._KEY_.truststore-authentication.keystore-path:: 
 The path of the keystore, will be ignored if the keystore-provider is anything other than JKS.
 
@@ -731,6 +785,9 @@ The provider for loading the keystore, defaults to JKS.
 
 swarm.management.security-realms._KEY_.truststore-authentication.keystore-relative-to:: 
 The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
+
+swarm.management.security-realms._KEY_.users-authentication.users._KEY_.credential-reference:: 
+The reference to credential for the password stored in CredentialStore under defined alias or clear text password.
 
 swarm.management.security-realms._KEY_.users-authentication.users._KEY_.password:: 
 The user's password.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-config.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-config.adoc
@@ -1,0 +1,30 @@
+= Eclipse MicroProfile Config
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>microprofile-config</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.microprofile.config.config-source-providers._KEY_.attribute-class:: 
+Class of the ConfigSourceProvider to load
+
+swarm.microprofile.config.config-sources._KEY_.attribute-class:: 
+Class of the config source to load
+
+swarm.microprofile.config.config-sources._KEY_.dir:: 
+Directory that is scanned to config properties for this config source (file names are key, file content are value)
+
+swarm.microprofile.config.config-sources._KEY_.ordinal:: 
+Ordinal value for the config source
+
+swarm.microprofile.config.config-sources._KEY_.properties:: 
+Properties configured for this config source
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-fault-tolerance.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-fault-tolerance.adoc
@@ -1,0 +1,30 @@
+
+= Microprofile Fault Tolerance Fraction
+:icons: font
+
+This fraction implements the https://github.com/eclipse/microprofile-fault-tolerance[Eclipse Microprofile Fault tolerance API^].
+The implementation depends on the xref:_hystrix[Hystrix fraction], which is added transitively into your application.
+Use xref:configuring-a-wildfly-swarm-application[standard configuration mechanisms] to configure Hystrix properties in your application.
+
+== Bulkhead fallback rejection
+
+If you use the semaphore-style `@Bulkhead` pattern with a `@Fallback` logic to limit the number of concurrent requests, the invocation may still result in a `BulkheadException` if the maximum concurrent limit for the `HystrixCommand.getFallback()` method is reached.
+To avoid that, set the `swarm.hystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests` property to increase the limit.
+
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>microprofile-fault-tolerance</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.microprofile.fault-tolerance.synchronous-circuit-breaker:: 
+Enable/disable synchronous circuit breaker functionality. If disabled, `CircuitBreaker#successThreshold()` of value greater than 1 is not supported. Moreover, circuit breaker does not necessarily transition from `CLOSED` to `OPEN` immediately when a fault tolerance operation completes. However, applications are encouraged to disable this feature on high-volume circuits.
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-health.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-health.adoc
@@ -1,0 +1,18 @@
+= Microprofile-Health
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>microprofile-health</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.microprofile.health.security-realm:: 
+Security realm configuration
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-jwt.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-jwt.adoc
@@ -1,0 +1,27 @@
+= MicroProfile JWT RBAC Auth Fraction
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>microprofile-jwt</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.microprofile.jwt.default-missing-method-permissions-deny-access:: 
+If a JAX-RS resource has no class-level security metadata, then if this property is set to `true` and at least one resource method has security metadata all other resource methods without security metadata have an implicit `@DenyAll`, otherwise resource methods without security metadata are not secured
+
+swarm.microprofile.jwt.token.exp-grace-period:: 
+The JWT token expiration grace period in seconds 
+
+swarm.microprofile.jwt.token.issued-by:: 
+The URI of the JWT token issuer
+
+swarm.microprofile.jwt.token.signer-pub-key:: 
+The public key of the JWT token signer. Can be prefixed 'file:' or 'classpath:' for key assets, otherwise the key contents are expected
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-metrics.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/microprofile-metrics.adoc
@@ -1,0 +1,41 @@
+= Microprofile Metrics Fraction
+:icons: font
+
+This fraction implements the https://github.com/eclipse/microprofile-metrics/releases/tag/1.0[MicroProfile Metrics 1.0 specification].
+
+To use this in your project you need the following in your pom.xml
+
+[source,xml]
+----
+   <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-metrics</artifactId>
+    </dependency>
+----
+
+There is no need to include the MicroProfile Metrics API dependency, as it comes with the fraction.
+
+By default the base metrics and vendor metrics of the server are exposed as required by the spec.
+
+NOTE: Exposing application metrics currently only works if you chose `war` packaging of your application
+
+[source,xml]
+----
+<project>
+  <groupId>org.example</groupId>
+  <artifactId>swarm-demo</artifactId>
+  <packaging>war</packaging> <!--1-->
+----
+<1> war packaging
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>microprofile-metrics</artifactId>
+</dependency>
+----
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/monitor.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/monitor.adoc
@@ -1,5 +1,9 @@
 = Monitor
 
+WARNING: This fraction is deprecated.
+Use the `org.wildfly.swarm:microprofile-health` fraction instead.
+
+
 
 .Maven Coordinates
 [source,xml]

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/msc.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/msc.adoc
@@ -1,4 +1,4 @@
-# MSC
+= MSC
 
 Primarily an internal fraction providing support for the 
 JBoss Modular Container (MSC). JBoss MSC provides the underpinning

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/naming.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/naming.adoc
@@ -1,4 +1,4 @@
-# Naming
+= Naming
 
 Provides support for JNDI.
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/netflix-guava.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/netflix-guava.adoc
@@ -1,6 +1,4 @@
-= JSON-P
-
-Provides support for JSON Processing according to JSR-353.
+= Guava
 
 
 .Maven Coordinates
@@ -8,7 +6,7 @@ Provides support for JSON Processing according to JSR-353.
 ----
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>jsonp</artifactId>
+  <artifactId>netflix-guava</artifactId>
 </dependency>
 ----
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/netflix-rxjava.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/netflix-rxjava.adoc
@@ -1,6 +1,4 @@
-= JSON-P
-
-Provides support for JSON Processing according to JSR-353.
+= RX-Java
 
 
 .Maven Coordinates
@@ -8,7 +6,7 @@ Provides support for JSON Processing according to JSR-353.
 ----
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>jsonp</artifactId>
+  <artifactId>netflix-rxjava</artifactId>
 </dependency>
 ----
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/opentracing.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/opentracing.adoc
@@ -1,0 +1,18 @@
+= OpenTracing
+
+
+.Maven Coordinates
+[source,xml]
+----
+<dependency>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>opentracing</artifactId>
+</dependency>
+----
+
+.Configuration
+
+swarm.opentracing.servlet.skipPattern:: 
+The servlet skip pattern as a Java compilable Pattern. Optional. Ex.: `/health-check`
+
+

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/remoting.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/remoting.adoc
@@ -1,4 +1,4 @@
-# Remoting
+= Remoting
 
 Primarily an internal fraction providing remote invocation
 support for higher-level fractions such as EJB.
@@ -20,6 +20,9 @@ The "authentication-provider" element contains the name of the authentication pr
 
 swarm.remoting.connectors._KEY_.properties._KEY_.value:: 
 The property value.
+
+swarm.remoting.connectors._KEY_.sasl-authentication-factory:: 
+Reference to the SASL authentication factory to secure this connector.
 
 swarm.remoting.connectors._KEY_.sasl-protocol:: 
 The protocol to pass into the SASL mechanisms used for authentication.
@@ -67,7 +70,10 @@ swarm.remoting.connectors._KEY_.server-name::
 The server name to send in the initial message exchange and for SASL based authentication.
 
 swarm.remoting.connectors._KEY_.socket-binding:: 
-The name (or names) of the socket binding(s) to attach to.
+The name of the socket binding to attach to.
+
+swarm.remoting.connectors._KEY_.ssl-context:: 
+Reference to the SSLContext to use for this connector.
 
 swarm.remoting.endpoint-configuration.auth-realm:: 
 The authentication realm to use if no authentication {@code CallbackHandler} is specified.
@@ -85,22 +91,22 @@ swarm.remoting.endpoint-configuration.heartbeat-interval::
 The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound directionfor this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
 
 swarm.remoting.endpoint-configuration.max-inbound-channels:: 
-The maximum number of concurrent inbound messages on a channel.
+The maximum number of inbound channels to support for a connection.
 
 swarm.remoting.endpoint-configuration.max-inbound-message-size:: 
 The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
 
 swarm.remoting.endpoint-configuration.max-inbound-messages:: 
-The maximum number of inbound channels to support for a connection.
+The maximum number of concurrent inbound messages on a channel.
 
 swarm.remoting.endpoint-configuration.max-outbound-channels:: 
-The maximum number of concurrent outbound messages on a channel.
+The maximum number of outbound channels to support for a connection.
 
 swarm.remoting.endpoint-configuration.max-outbound-message-size:: 
 The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
 
 swarm.remoting.endpoint-configuration.max-outbound-messages:: 
-The maximum number of outbound channels to support for a connection.
+The maximum number of concurrent outbound messages on a channel.
 
 swarm.remoting.endpoint-configuration.receive-buffer-size:: 
 The size of the largest buffer that this endpoint will accept over a connection.
@@ -131,6 +137,9 @@ The name (or names) of a connector in the Undertow subsystem to connect to.
 
 swarm.remoting.http-connectors._KEY_.properties._KEY_.value:: 
 The property value.
+
+swarm.remoting.http-connectors._KEY_.sasl-authentication-factory:: 
+Reference to the SASL authentication factory to use for this connector.
 
 swarm.remoting.http-connectors._KEY_.sasl-protocol:: 
 The protocol to pass into the SASL mechanisms used for authentication.
@@ -192,6 +201,9 @@ The connection URI for the outbound connection.
 swarm.remoting.port:: 
 Port for legacy remoting connector
 
+swarm.remoting.remote-outbound-connections._KEY_.authentication-context:: 
+Reference to the authentication context instance containing the configuration for outbound connections.
+
 swarm.remoting.remote-outbound-connections._KEY_.outbound-socket-binding-ref:: 
 Name of the outbound-socket-binding which will be used to determine the destination address and port for the connection.
 
@@ -199,7 +211,7 @@ swarm.remoting.remote-outbound-connections._KEY_.properties._KEY_.value::
 The property value.
 
 swarm.remoting.remote-outbound-connections._KEY_.protocol:: 
-The protocol to use for the remote connection. Defaults to http-remoting.
+The protocol to use for the remote connection.
 
 swarm.remoting.remote-outbound-connections._KEY_.security-realm:: 
 Reference to the security realm to use to obtain the password and SSL configuration.
@@ -209,5 +221,23 @@ The user name to use when authenticating against the remote server.
 
 swarm.remoting.required:: 
 (not yet documented)
+
+swarm.remoting.worker-read-threads:: 
+The number of read threads to create for the remoting worker.
+
+swarm.remoting.worker-task-core-threads:: 
+The number of core threads for the remoting worker task thread pool.
+
+swarm.remoting.worker-task-keepalive:: 
+The number of milliseconds to keep non-core remoting worker task threads alive.
+
+swarm.remoting.worker-task-limit:: 
+The maximum number of remoting worker tasks to allow before rejecting.
+
+swarm.remoting.worker-task-max-threads:: 
+The maximum number of threads for the remoting worker task thread pool.
+
+swarm.remoting.worker-write-threads:: 
+The number of write threads to create for the remoting worker.
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/request-controller.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/request-controller.adoc
@@ -1,6 +1,6 @@
-# Request Controller
+= Request Controller
 
-Provides support for the WildFly request-controller, allowing
+Provides support for the {WildFly} request-controller, allowing
 for graceful pause/resume/shutdown of the container.
 
 
@@ -19,7 +19,7 @@ swarm.request-controller.active-requests::
 The number of requests that are currently running in the server
 
 swarm.request-controller.max-requests:: 
-The maximum number of all types of requests that can be running in a server at a time
+The maximum number of all types of requests that can be running in a server at a time. Once this limit is hit any new requests will be rejected.
 
 swarm.request-controller.track-individual-endpoints:: 
 If this is true requests are tracked at an endpoint level, which will allow individual deployments to be suspended

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/security.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/security.adoc
@@ -1,4 +1,4 @@
-# Security
+= Security
 
 Provides underlying security infrastructure to support JAAS
 and other security APIs.
@@ -24,6 +24,27 @@ Security Vault options.
 swarm.security.deep-copy-subject-mode:: 
 Sets the copy mode of subjects done by the security managers to be deep copies that makes copies of the subject principals and credentials if they are cloneable. It should be set to true if subject include mutable content that can be corrupted when multiple threads have the same identity and cache flushes/logout clearing the subject in one thread results in subject references affecting other threads.
 
+swarm.security.elytron-key-managers._KEY_.legacy-jsse-config:: 
+The name of the legacy security domain that contains a JSSE configuration that can be used to export the key manager.
+
+swarm.security.elytron-key-stores._KEY_.legacy-jsse-config:: 
+The name of the legacy security domain that contains a JSSE configuration that can be used to export the key store.
+
+swarm.security.elytron-realms._KEY_.apply-role-mappers:: 
+Indicates to the realm if it should apply the role mappers defined in the legacy domain to the roles obtained from authenticated Subjects or not.
+
+swarm.security.elytron-realms._KEY_.legacy-jaas-config:: 
+The name of the legacy security domain to which authentication will be delegated.
+
+swarm.security.elytron-trust-managers._KEY_.legacy-jsse-config:: 
+The name of the legacy security domain that contains a JSSE configuration that can be used to export the trust manager.
+
+swarm.security.elytron-trust-stores._KEY_.legacy-jsse-config:: 
+The name of the legacy security domain that contains a JSSE configuration that can be used to export the trust store.
+
+swarm.security.initialize-jacc:: 
+Indicates if this subsystem should be in charge of initializing JACC related services.
+
 swarm.security.security-domains._KEY_.cache-type:: 
 Adds a cache to speed up authentication checks. Allowed values are 'default' to use simple map as the cache and 'infinispan' to use an Infinispan cache.
 
@@ -41,6 +62,9 @@ List of module options containing a name/value pair.
 
 swarm.security.security-domains._KEY_.classic-audit.provider-modules._KEY_.code:: 
 Class name of the module to be instantiated.
+
+swarm.security.security-domains._KEY_.classic-audit.provider-modules._KEY_.module:: 
+Name of JBoss Module where the mapping module code is located.
 
 swarm.security.security-domains._KEY_.classic-audit.provider-modules._KEY_.module-options:: 
 List of module options containing a name/value pair.

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/transactions.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/transactions.adoc
@@ -1,4 +1,4 @@
-# Transactions
+= Transactions
 
 Provides support for the Java Transaction API (JTA) according to 
 JSR-907.
@@ -15,6 +15,9 @@ JSR-907.
 
 .Configuration
 
+swarm.transactions.average-commit-time:: 
+The average time of transaction commit in nanoseconds, measured from the moment the client calls commit until the transaction manager determines that the commit attempt was successful.
+
 swarm.transactions.commit-markable-resources._KEY_.batch-size:: 
 Batch size for this CMR resource
 
@@ -28,37 +31,43 @@ swarm.transactions.commit-markable-resources._KEY_.name::
 table name for storing XIDs
 
 swarm.transactions.default-timeout:: 
-The default timeout.
+The default timeout for a transaction managed by the transaction manager.
+
+swarm.transactions.enable-statistics:: 
+Whether transaction statistics should be gathered.
 
 swarm.transactions.enable-tsm-status:: 
-Whether the transaction status manager (TSM) service, needed for out of process recovery, should be provided or not..
+Whether the transaction status manager (TSM) service, needed for out of process recovery, should be provided or not.
+
+swarm.transactions.hornetq-store-enable-async-io:: 
+Whether AsyncIO should be enabled for the journal store.
 
 swarm.transactions.jdbc-action-store-drop-table:: 
-Configure if jdbc action store should drop tables. Default is false. The server should be restarted for this setting to take effect.
+Configure if jdbc action store should drop tables.
 
 swarm.transactions.jdbc-action-store-table-prefix:: 
-Optional prefix for table used to write transcation logs in configured jdbc action store. The server should be restarted for this setting to take effect.
+Optional prefix for table used to write transaction logs in configured jdbc action store.
 
 swarm.transactions.jdbc-communication-store-drop-table:: 
-Configure if jdbc communication store should drop tables. Default is false. The server should be restarted for this setting to take effect.
+Configure if jdbc communication store should drop tables.
 
 swarm.transactions.jdbc-communication-store-table-prefix:: 
-Optional prefix for table used to write transcation logs in configured jdbc communication store. The server should be restarted for this setting to take effect.
+Optional prefix for table used to write transaction logs in configured jdbc communication store.
 
 swarm.transactions.jdbc-state-store-drop-table:: 
-Configure if jdbc state store should drop tables. Default is false. The server should be restarted for this setting to take effect.
+Configure if jdbc state store should drop tables.
 
 swarm.transactions.jdbc-state-store-table-prefix:: 
-Optional prefix for table used to write transcation logs in configured jdbc state store. The server should be restarted for this setting to take effect.
+Optional prefix for table used to write transaction logs in configured jdbc state store.
 
 swarm.transactions.jdbc-store-datasource:: 
-Jndi name of non-XA datasource used. Datasource sghould be define in datasources subsystem. The server should be restarted for this setting to take effect.
+Jndi name of non-XA datasource used. Datasource sghould be define in datasources subsystem. For this would work the non-XA datasource has to be marked as jta="false".
 
 swarm.transactions.journal-store-enable-async-io:: 
-Whether AsyncIO should be enabled for the journal store. Default is false. The server should be restarted for this setting to take effect.
+Whether AsyncIO should be enabled for the journal store. For this settings being active journal natives libraries needs to be available.
 
 swarm.transactions.jts:: 
-If true this enables the Java Transaction Service.
+If true this enables the Java Transaction Service. Use of the JTS needs configuration in IIOP OpenJDK where Transactions parameter needs to be set to full.
 
 swarm.transactions.log-store.expose-all-logs:: 
 Whether to expose all logs like orphans etc. By default only a subset of transaction logs is exposed.
@@ -97,7 +106,7 @@ swarm.transactions.log-store.type::
 Specifies the implementation type of the logging store.
 
 swarm.transactions.node-identifier:: 
-Used to set the node identifier on the core environment.
+Used to set the node identifier on the core environment. Each Xid that Transaction Manager creates will have this identifier encoded within it and ensures Transaction Manager will only recover branches which match the specified identifier. It is imperative that this identifier is unique between Application Server instances which share either an object store or access common resource managers.
 
 swarm.transactions.number-of-aborted-transactions:: 
 The number of aborted (i.e. rolledback) transactions.
@@ -120,6 +129,9 @@ The total number of nested (sub) transactions created.
 swarm.transactions.number-of-resource-rollbacks:: 
 The number of transactions that rolled back due to resource (participant) failure.
 
+swarm.transactions.number-of-system-rollbacks:: 
+The number of transactions that have been rolled back due to internal system errors.
+
 swarm.transactions.number-of-timed-out-transactions:: 
 The number of transactions that have rolled back due to timeout.
 
@@ -127,10 +139,10 @@ swarm.transactions.number-of-transactions::
 The total number of transactions (top-level and nested) created
 
 swarm.transactions.object-store-path:: 
-Denotes a relative or absolute filesystem path denoting where the transaction manager object store should store data. By default the value is treated as relative to the path denoted by the "relative-to" attribute.
+Denotes a relative or absolute filesystem path denoting where the transaction manager object store should store data. By default the value is treated as relative to the path denoted by the "relative-to" attribute. This settings is valid when default or journal store is used. It's not used when jdbc journal store is used.
 
 swarm.transactions.object-store-relative-to:: 
-References a global path configuration in the domain model, defaulting to the JBoss Application Server data directory (jboss.server.data.dir). The value of the "path" attribute will treated as relative to this path. Use an empty string to disable the default behavior and force the value of the "path" attribute to be treated as an absolute path.
+References a global path configuration in the domain model, defaulting to the Application Server data directory (jboss.server.data.dir). The value of the "Object store path" attribute will treated as relative to this path. Undefine this attribute to disable the default behavior and force the value of the "Object store path" attribute to be treated as an absolute path.
 
 swarm.transactions.port:: 
 Port for transaction manager
@@ -151,7 +163,7 @@ swarm.transactions.socket-binding::
 Used to reference the correct socket binding to use for the recovery environment.
 
 swarm.transactions.statistics-enabled:: 
-Whether statistics should be enabled.
+Whether transaction statistics should be gathered.
 
 swarm.transactions.status-port:: 
 Status port for transaction manager
@@ -159,10 +171,13 @@ Status port for transaction manager
 swarm.transactions.status-socket-binding:: 
 Used to reference the correct socket binding to use for the transaction status manager.
 
+swarm.transactions.use-hornetq-store:: 
+Use the journal store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file system file per transaction log.It's alternative to jdbc based store.
+
 swarm.transactions.use-jdbc-store:: 
-Use the jdbc store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file system file per transaction log. The server should be restarted for this setting to take effect. It's alternative to Horneq based store
+Use the jdbc store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file file per transaction log. It's alternative to journal based store.
 
 swarm.transactions.use-journal-store:: 
-Use the journal store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file system file per transaction log. The server should be restarted for this setting to take effect. It's alternative to jdbc based store.
+Use the journal store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store creates normally one file system file per transaction log. The journal one consists from one file for all the transactions. It's alternative to jdbc based store.
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/undertow.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/undertow.adoc
@@ -1,4 +1,4 @@
-# Undertow
+= Undertow
 
 Provides basic HTTP support, including Java Servlets, JavaServer Pages (JSP),
 and JavaServer Pages Standard Tag Library (JSTL) according to JSR-340, JSR-245
@@ -34,8 +34,20 @@ Should a self-signed certificate be generated
 swarm.https.certificate.generate.host:: 
 Hostname for the generated self-signed certificate
 
+swarm.https.key.alias:: 
+Alias to the server certificate key entry in the keystore
+
+swarm.https.key.password:: 
+Password to the server certificate
+
 swarm.https.keystore.embedded:: 
 Should an embedded keystore be created
+
+swarm.https.keystore.password:: 
+Password to the server keystore
+
+swarm.https.keystore.path:: 
+Path to the server keystore
 
 swarm.https.only:: 
 Only enable the HTTPS  Listener
@@ -43,8 +55,44 @@ Only enable the HTTPS  Listener
 swarm.https.port:: 
 Set the port for the default HTTPS listener
 
-swarm.undertow.alias:: 
-Alias to the server certificate key entry in the keystore
+swarm.undertow.application-security-domains._KEY_.enable-jacc:: 
+Enable authorization using JACC
+
+swarm.undertow.application-security-domains._KEY_.http-authentication-factory:: 
+The HTTP Authentication Factory to be used by deployments that reference the mapped security domain.
+
+swarm.undertow.application-security-domains._KEY_.override-deployment-config:: 
+Should the authentication configuration in the deployment be overridden by the factory.
+
+swarm.undertow.application-security-domains._KEY_.referencing-deployments:: 
+The deployments currently referencing this mapping.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.client-ssl-context:: 
+Reference to the SSL context used to secure back-channel logout connection.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.cookie-name:: 
+Name of the cookie
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.credential-reference:: 
+The credential reference to decrypt the private key entry.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.domain:: 
+The cookie domain that will be used.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.http-only:: 
+Set Cookie httpOnly attribute.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.key-alias:: 
+Alias of the private key entry used for signing and verifying back-channel logout connection.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.key-store:: 
+Reference to key store containing a private key entry.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.path:: 
+Cookie path.
+
+swarm.undertow.application-security-domains._KEY_.single-sign-on-setting.secure:: 
+Set Cookie secure attribute.
 
 swarm.undertow.buffer-caches._KEY_.buffer-size:: 
 The size of an individual buffer, in bytes.
@@ -92,13 +140,13 @@ swarm.undertow.filter-configuration.mod-clusters._KEY_.advertise-frequency::
 The frequency (in milliseconds) that mod-cluster advertises itself on the network
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.advertise-path:: 
-The path that mod-cluster is registered under, defaults to /
+The path that mod-cluster is registered under.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.advertise-protocol:: 
-The protocol that is in use, defaults to HTTP
+The protocol that is in use.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.advertise-socket-binding:: 
-The multicast group that is used to advertise
+The multicast group and port that is used to advertise.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.balancers._KEY_.max-attempts:: 
 The number of attempts to send the request to a backend server
@@ -188,10 +236,13 @@ swarm.undertow.filter-configuration.mod-clusters._KEY_.connection-idle-timeout::
 The amount of time a connection can be idle before it will be closed. Connections will not time out once the pool size is down to the configured minimum (as configured by cached-connections-per-thread)
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.connections-per-thread:: 
-The number of connections that will be maintained to backend servers, per IO thread. Defaults to 10.
+The number of connections that will be maintained to backend servers, per IO thread.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.enable-http2:: 
 If the load balancer should attempt to upgrade back end connections to HTTP2. If HTTP2 is not supported HTTP or HTTPS will be used as normal
+
+swarm.undertow.filter-configuration.mod-clusters._KEY_.failover-strategy:: 
+Determines how a failover node is chosen, in the event that the node to which a session has affinity is not available.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.health-check-interval:: 
 The frequency of health check pings to backend nodes
@@ -218,13 +269,16 @@ swarm.undertow.filter-configuration.mod-clusters._KEY_.management-access-predica
 A predicate that is applied to incoming requests to determine if they can perform mod cluster management commands. Provides additional security on top of what is provided by limiting management to requests that originate from the management-socket-binding
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.management-socket-binding:: 
-The socket binding of the mod_cluster management port. When using mod_cluster two HTTP listeners should be defined, a public one to handle requests, and one bound to the internal network to handle mod cluster commands. This socket binding should correspond to the internal listener, and should not be publicly accessible
+The socket binding of the mod_cluster management address and port. When using mod_cluster two HTTP listeners should be defined, a public one to handle requests, and one bound to the internal network to handle mod cluster commands. This socket binding should correspond to the internal listener, and should not be publicly accessible.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.max-ajp-packet-size:: 
 The maximum size for AJP packets. Increasing this will allow AJP to work for requests/responses that have a large amount of headers. This is an advanced option, and must be the same between load balancers and backend servers.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.max-request-time:: 
 The max amount of time that a request to a backend node can take before it is killed
+
+swarm.undertow.filter-configuration.mod-clusters._KEY_.max-retries:: 
+The number of times to attempt to retry a request if it fails. Note that if a request is not considered idempotent then it will only be retried if the proxy can be sure it was not sent to the backend server).
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.request-queue-size:: 
 The number of requests that can be queued if the connection pool is full before requests are rejected with a 503
@@ -234,6 +288,9 @@ The security key that is used for the mod-cluster group. All members must use th
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.security-realm:: 
 The security realm that provides the SSL configuration
+
+swarm.undertow.filter-configuration.mod-clusters._KEY_.ssl-context:: 
+Reference to the SSLContext to be used by this filter.
 
 swarm.undertow.filter-configuration.mod-clusters._KEY_.use-alias:: 
 If an alias check is performed
@@ -287,7 +344,10 @@ swarm.undertow.handler-configuration.reverse-proxies._KEY_.connection-idle-timeo
 The amount of time a connection can be idle before it will be closed. Connections will not time out once the pool size is down to the configured minimum (as configured by cached-connections-per-thread)
 
 swarm.undertow.handler-configuration.reverse-proxies._KEY_.connections-per-thread:: 
-The number of connections that will be maintained to backend servers, per IO thread. Defaults to 10.
+The number of connections that will be maintained to backend servers, per IO thread.
+
+swarm.undertow.handler-configuration.reverse-proxies._KEY_.hosts._KEY_.enable-http2:: 
+If this is true then the proxy will attempt to use HTTP/2 to connect to the backend. If it is not supported it will fall back to HTTP/1.1/
 
 swarm.undertow.handler-configuration.reverse-proxies._KEY_.hosts._KEY_.instance-id:: 
 The instance id (aka JVM route) that will be used to enable sticky sessions
@@ -304,8 +364,14 @@ What kind of scheme is used
 swarm.undertow.handler-configuration.reverse-proxies._KEY_.hosts._KEY_.security-realm:: 
 The security realm that provides the SSL configuration for the connection to the host
 
+swarm.undertow.handler-configuration.reverse-proxies._KEY_.hosts._KEY_.ssl-context:: 
+Reference to the SSLContext to be used by this handler.
+
 swarm.undertow.handler-configuration.reverse-proxies._KEY_.max-request-time:: 
-The maximum time that a proxy request can be active for, before being killed. Defaults to unlimited
+The maximum time that a proxy request can be active for, before being killed
+
+swarm.undertow.handler-configuration.reverse-proxies._KEY_.max-retries:: 
+The number of times to attempt to retry a request if it fails. Note that if a request is not considered idempotent then it will only be retried if the proxy can be sure it was not sent to the backend server).
 
 swarm.undertow.handler-configuration.reverse-proxies._KEY_.problem-server-retry:: 
 Time in seconds to wait before attempting to reconnect to a server that is down
@@ -318,15 +384,6 @@ Comma separated list of session cookie names. Generally this will just be JSESSI
 
 swarm.undertow.instance-id:: 
 The cluster instance id
-
-swarm.undertow.key-password:: 
-Password to the server certificate
-
-swarm.undertow.keystore-password:: 
-Password to the server keystore
-
-swarm.undertow.keystore-path:: 
-Path to the server keystore
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.allow-encoded-slash:: 
 If a request comes in with encoded / characters (i.e. %2F), will these be decoded.
@@ -354,9 +411,6 @@ If this is true then the parser will decode the URL and query parameters using t
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.disallowed-methods:: 
 A comma separated list of HTTP methods that are not allowed
-
-swarm.undertow.servers._KEY_.ajp-listeners._KEY_.enabled:: 
-If the listener is enabled
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.error-count:: 
 The number of 500 responses that have been sent by this listener
@@ -389,7 +443,7 @@ swarm.undertow.servers._KEY_.ajp-listeners._KEY_.max-processing-time::
 The maximum processing time taken by a request on this listener
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.no-request-timeout:: 
-The length of time in milliseconds that the connection can be idle before it is closed by the container, defaults to 60000 (one minute)
+The length of time in milliseconds that the connection can be idle before it is closed by the container.
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.processing-time:: 
 The total processing time of all requests handed by this listener
@@ -414,6 +468,9 @@ The maximum amount of time (in milliseconds) that can be spent parsing the reque
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.resolve-peer-address:: 
 Enables host dns lookup
+
+swarm.undertow.servers._KEY_.ajp-listeners._KEY_.rfc6265-cookie-validation:: 
+If cookies should be validated to ensure they comply with RFC6265.
 
 swarm.undertow.servers._KEY_.ajp-listeners._KEY_.scheme:: 
 The listener scheme, can be HTTP or HTTPS. By default the scheme will be taken from the incoming AJP request.
@@ -470,7 +527,7 @@ swarm.undertow.servers._KEY_.hosts._KEY_.access-log-setting.suffix::
 Suffix for the log file name.
 
 swarm.undertow.servers._KEY_.hosts._KEY_.access-log-setting.use-server-log:: 
-If the log should be written to the server log, rather than a separate file. Defaults to false.
+If the log should be written to the server log, rather than a separate file.
 
 swarm.undertow.servers._KEY_.hosts._KEY_.access-log-setting.worker:: 
 Name of the worker to use for logging
@@ -492,6 +549,15 @@ Predicates provide a simple way of making a true/false decision  based on an exc
 
 swarm.undertow.servers._KEY_.hosts._KEY_.filter-refs._KEY_.priority:: 
 Defines filter order, it should be set to 1 or more, higher number instructs server to be included earlier in handler chain than others under same context.
+
+swarm.undertow.servers._KEY_.hosts._KEY_.http-invoker-setting.http-authentication-factory:: 
+The HTTP authentication factory to use for authentication
+
+swarm.undertow.servers._KEY_.hosts._KEY_.http-invoker-setting.path:: 
+The path that the services are installed under
+
+swarm.undertow.servers._KEY_.hosts._KEY_.http-invoker-setting.security-realm:: 
+The legacy security realm to use for authentication
 
 swarm.undertow.servers._KEY_.hosts._KEY_.locations._KEY_.filter-refs._KEY_.predicate:: 
 Predicates provide a simple way of making a true/false decision  based on an exchange. Many handlers have a requirement that they be applied conditionally, and predicates provide a general way to specify a condition.
@@ -550,9 +616,6 @@ A comma separated list of HTTP methods that are not allowed
 swarm.undertow.servers._KEY_.http-listeners._KEY_.enable-http2:: 
 Enables HTTP2 support for this listener
 
-swarm.undertow.servers._KEY_.http-listeners._KEY_.enabled:: 
-If the listener is enabled
-
 swarm.undertow.servers._KEY_.http-listeners._KEY_.error-count:: 
 The number of 500 responses that have been sent by this listener
 
@@ -599,13 +662,13 @@ swarm.undertow.servers._KEY_.http-listeners._KEY_.max-processing-time::
 The maximum processing time taken by a request on this listener
 
 swarm.undertow.servers._KEY_.http-listeners._KEY_.no-request-timeout:: 
-The length of time in milliseconds that the connection can be idle before it is closed by the container, defaults to 60000 (one minute)
+The length of time in milliseconds that the connection can be idle before it is closed by the container.
 
 swarm.undertow.servers._KEY_.http-listeners._KEY_.processing-time:: 
 The total processing time of all requests handed by this listener
 
 swarm.undertow.servers._KEY_.http-listeners._KEY_.proxy-address-forwarding:: 
-enables x-forwarded-host and similar headers and set a remote ip address and hostname
+Enables  handling of x-forwarded-host header (and other x-forwarded-* headers) and use this header information to set the remote address. This should only be used behind a trusted proxy that sets these headers otherwise a remote user can spoof their IP address.
 
 swarm.undertow.servers._KEY_.http-listeners._KEY_.read-timeout:: 
 Configure a read timeout for a socket, in milliseconds.  If the given amount of time elapses without a successful read taking place, the socket's next read will throw a {@link ReadTimeoutException}.
@@ -625,8 +688,14 @@ The number of requests this listener has served
 swarm.undertow.servers._KEY_.http-listeners._KEY_.request-parse-timeout:: 
 The maximum amount of time (in milliseconds) that can be spent parsing the request
 
+swarm.undertow.servers._KEY_.http-listeners._KEY_.require-host-http11:: 
+Require that all HTTP/1.1 requests have a 'Host' header, as per the RFC. IF the request does not include this header it will be rejected with a 403.
+
 swarm.undertow.servers._KEY_.http-listeners._KEY_.resolve-peer-address:: 
 Enables host dns lookup
+
+swarm.undertow.servers._KEY_.http-listeners._KEY_.rfc6265-cookie-validation:: 
+If cookies should be validated to ensure they comply with RFC6265.
 
 swarm.undertow.servers._KEY_.http-listeners._KEY_.secure:: 
 If this is true then requests that originate from this listener are marked as secure, even if the request is not using HTTPS.
@@ -673,6 +742,9 @@ The number of bytes that have been received by this listener
 swarm.undertow.servers._KEY_.https-listeners._KEY_.bytes-sent:: 
 The number of bytes that have been sent out on this listener
 
+swarm.undertow.servers._KEY_.https-listeners._KEY_.certificate-forwarding:: 
+If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+
 swarm.undertow.servers._KEY_.https-listeners._KEY_.decode-url:: 
 If this is true then the parser will decode the URL and query parameters using the selected character encoding (UTF-8 by default). If this is false they will not be decoded. This will allow a later handler to decode them into whatever charset is desired.
 
@@ -682,11 +754,8 @@ A comma separated list of HTTP methods that are not allowed
 swarm.undertow.servers._KEY_.https-listeners._KEY_.enable-http2:: 
 Enables HTTP2 support for this listener
 
-swarm.undertow.servers._KEY_.https-listeners._KEY_.enabled:: 
-If the listener is enabled
-
 swarm.undertow.servers._KEY_.https-listeners._KEY_.enabled-cipher-suites:: 
-Configures Enabled SSL cyphers
+Configures Enabled SSL ciphers
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.enabled-protocols:: 
 Configures SSL protocols
@@ -737,10 +806,13 @@ swarm.undertow.servers._KEY_.https-listeners._KEY_.max-processing-time::
 The maximum processing time taken by a request on this listener
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.no-request-timeout:: 
-The length of time in milliseconds that the connection can be idle before it is closed by the container, defaults to 60000 (one minute)
+The length of time in milliseconds that the connection can be idle before it is closed by the container.
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.processing-time:: 
 The total processing time of all requests handed by this listener
+
+swarm.undertow.servers._KEY_.https-listeners._KEY_.proxy-address-forwarding:: 
+Enables  handling of x-forwarded-host header (and other x-forwarded-* headers) and use this header information to set the remote address. This should only be used behind a trusted proxy that sets these headers otherwise a remote user can spoof their IP address.
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.read-timeout:: 
 Configure a read timeout for a socket, in milliseconds.  If the given amount of time elapses without a successful read taking place, the socket's next read will throw a {@link ReadTimeoutException}.
@@ -757,8 +829,14 @@ The number of requests this listener has served
 swarm.undertow.servers._KEY_.https-listeners._KEY_.request-parse-timeout:: 
 The maximum amount of time (in milliseconds) that can be spent parsing the request
 
+swarm.undertow.servers._KEY_.https-listeners._KEY_.require-host-http11:: 
+Require that all HTTP/1.1 requests have a 'Host' header, as per the RFC. IF the request does not include this header it will be rejected with a 403.
+
 swarm.undertow.servers._KEY_.https-listeners._KEY_.resolve-peer-address:: 
 Enables host dns lookup
+
+swarm.undertow.servers._KEY_.https-listeners._KEY_.rfc6265-cookie-validation:: 
+If cookies should be validated to ensure they comply with RFC6265.
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.secure:: 
 If this is true then requests that originate from this listener are marked as secure, even if the request is not using HTTPS.
@@ -771,6 +849,9 @@ The send buffer size, in bytes.
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.socket-binding:: 
 The listener socket binding
+
+swarm.undertow.servers._KEY_.https-listeners._KEY_.ssl-context:: 
+Reference to the SSLContext to be used by this listener.
 
 swarm.undertow.servers._KEY_.https-listeners._KEY_.ssl-session-cache-size:: 
 The maximum number of active SSL sessions
@@ -806,7 +887,7 @@ swarm.undertow.servlet-containers._KEY_.crawler-session-management-setting.sessi
 The session timeout for sessions that are owned by crawlers
 
 swarm.undertow.servlet-containers._KEY_.crawler-session-management-setting.user-agents:: 
-Regular expression that is used to match the user agenet of a crawler
+Regular expression that is used to match the user agent of a crawler
 
 swarm.undertow.servlet-containers._KEY_.default-buffer-cache:: 
 The buffer cache to use for caching static resources
@@ -823,6 +904,12 @@ If directory listing should be enabled for default servlets.
 swarm.undertow.servlet-containers._KEY_.disable-caching-for-secured-pages:: 
 If Undertow should set headers to disable caching for secured paged. Disabling this can cause security problems, as sensitive pages may be cached by an intermediary.
 
+swarm.undertow.servlet-containers._KEY_.disable-file-watch-service:: 
+If this is true then the file watch service will not be used to monitor exploded deployments for changes
+
+swarm.undertow.servlet-containers._KEY_.disable-session-id-reuse:: 
+If this is true then an unknown session ID will never be reused, and a new session id will be generated. If this is false then it will be re-used if and only if it is present in the session manager of another deployment, to allow the same session id to be shared between applications on the same server.
+
 swarm.undertow.servlet-containers._KEY_.eager-filter-initialization:: 
 If true undertow calls filter init() on deployment start rather than when first requested.
 
@@ -830,13 +917,13 @@ swarm.undertow.servlet-containers._KEY_.ignore-flush::
 Ignore flushes on the servlet output stream. In most cases these just hurt performance for no good reason.
 
 swarm.undertow.servlet-containers._KEY_.jsp-setting.check-interval:: 
-Check interval for JSP updates using a background thread.
+Check interval for JSP updates using a background thread. This has no effect for most deployments where JSP change notifications are handled using the File System notification API. This only takes effect if the file watch service is disabled.
 
 swarm.undertow.servlet-containers._KEY_.jsp-setting.development:: 
 Enable Development mode which enables reloading JSP on-the-fly
 
 swarm.undertow.servlet-containers._KEY_.jsp-setting.disabled:: 
-Enable the JSP container.
+Disable the JSP container.
 
 swarm.undertow.servlet-containers._KEY_.jsp-setting.display-source-fragment:: 
 When a runtime error occurs, attempts to display corresponding JSP source fragment
@@ -923,7 +1010,7 @@ swarm.undertow.servlet-containers._KEY_.session-cookie-setting.secure::
 Is cookie secure?
 
 swarm.undertow.servlet-containers._KEY_.session-id-length:: 
-The length of the generated session ID. Longer session ID's are more secure.
+The length of the generated session ID. Longer session ID's are more secure. This number refers to the number of bytes of randomness that are used to generate the session ID, the actual ID that is sent to the client will be base64 encoded so will be approximately 33% larger (e.g. a session id length of 30 will result in a cookie value of length 40).
 
 swarm.undertow.servlet-containers._KEY_.stack-trace-on-error:: 
 If an error page with the stack trace should be generated on error. Values are all, none and local-only
@@ -934,13 +1021,19 @@ Use encoding defined on listener
 swarm.undertow.servlet-containers._KEY_.websockets-setting.buffer-pool:: 
 The buffer pool to use for websocket deployments
 
+swarm.undertow.servlet-containers._KEY_.websockets-setting.deflater-level:: 
+Configures the level of compression of the DEFLATE algorithm
+
 swarm.undertow.servlet-containers._KEY_.websockets-setting.dispatch-to-worker:: 
 If callbacks should be dispatched to a worker thread. If this is false then they will be run in the IO thread, which is faster however care must be taken not to perform blocking operations.
+
+swarm.undertow.servlet-containers._KEY_.websockets-setting.per-message-deflate:: 
+Enables websocket's per-message compression extension, RFC-7692
 
 swarm.undertow.servlet-containers._KEY_.websockets-setting.worker:: 
 The worker to use for websocket deployments
 
 swarm.undertow.statistics-enabled:: 
-Configures if statistics are enabled
+Configures if statistics are enabled. Changes take effect on the connector level statistics immediately, deployment level statistics will only be affected after the deployment is redeployed (or the container is reloaded).
 
 

--- a/docs/topics/wildfly-swarm/docs/reference/fractions/web.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/fractions/web.adoc
@@ -1,4 +1,4 @@
-# Web
+= Web
 
 Provides a collection of fractions equivalent to the _Web Profile_:
 

--- a/docs/topics/wildfly-swarm/docs/reference/index.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/index.adoc
@@ -1,3 +1,5 @@
+include::fractions/archaius.adoc[leveloffset=+0]
+
 include::fractions/bean-validation.adoc[leveloffset=+0]
 
 include::fractions/cdi.adoc[leveloffset=+0]
@@ -14,9 +16,15 @@ include::fractions/ee.adoc[leveloffset=+0]
 
 include::fractions/ejb.adoc[leveloffset=+0]
 
+include::fractions/elytron.adoc[leveloffset=+0]
+
 include::fractions/hibernate-validator.adoc[leveloffset=+0]
 
+include::fractions/hystrix.adoc[leveloffset=+0]
+
 include::fractions/io.adoc[leveloffset=+0]
+
+include::fractions/jaeger.adoc[leveloffset=+0]
 
 include::fractions/jaxrs.adoc[leveloffset=+0]
 
@@ -48,11 +56,27 @@ include::fractions/management.adoc[leveloffset=+0]
 
 include::fractions/microprofile.adoc[leveloffset=+0]
 
+include::fractions/microprofile-config.adoc[leveloffset=+1]
+
+include::fractions/microprofile-fault-tolerance.adoc[leveloffset=+1]
+
+include::fractions/microprofile-health.adoc[leveloffset=+1]
+
+include::fractions/microprofile-jwt.adoc[leveloffset=+1]
+
+include::fractions/microprofile-metrics.adoc[leveloffset=+1]
+
 include::fractions/monitor.adoc[leveloffset=+0]
 
 include::fractions/msc.adoc[leveloffset=+0]
 
 include::fractions/naming.adoc[leveloffset=+0]
+
+include::fractions/netflix-guava.adoc[leveloffset=+0]
+
+include::fractions/netflix-rxjava.adoc[leveloffset=+0]
+
+include::fractions/opentracing.adoc[leveloffset=+0]
 
 include::fractions/remoting.adoc[leveloffset=+0]
 

--- a/docs/topics/wildfly-swarm/docs/reference/maven-plugin.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/maven-plugin.adoc
@@ -1,11 +1,11 @@
 [#maven-plugin]
 = Maven Plugin
 
-WildFly Swarm provides a Maven plugin to accomplish most of the work of building xref:uberjar[uberjar] packages.
+{Thorntail} provides a Maven plugin to accomplish most of the work of building xref:uberjar[uberjar] packages.
 
 .General Usage
 
-The WildFly Swarm Maven plugin is used like any other Maven plugin, that is through editing the `pom.xml` file in your application and adding a `<plugin>` section:
+The {Thorntail} Maven plugin is used like any other Maven plugin, that is through editing the `pom.xml` file in your application and adding a `<plugin>` section:
 
 [source,xml]
 ----
@@ -24,7 +24,7 @@ The WildFly Swarm Maven plugin is used like any other Maven plugin, that is thro
 
 == Goals
 
-The WildFly Swarm Maven plugin provides several goals:
+The {Thorntail} Maven plugin provides several goals:
 
 package::
 Creates the executable package (see xref:creating-an-uberjar[]).
@@ -35,7 +35,7 @@ Executes your application in the Maven process. The application is stopped if th
 [#maven-plugin-multistart-goal]
 start and multistart::
 Executes your application in a forked process. Generally, it is only useful for running integration tests using a plugin, such as the `maven-failsafe-plugin`.
-The `multistart` variant allows starting multiple WildFly Swarm{ndash}built applications using Maven GAVs to support complex testing scenarios.
+The `multistart` variant allows starting multiple {Thorntail}{ndash}built applications using Maven GAVs to support complex testing scenarios.
 
 stop::
 Stops any previously started applications.
@@ -70,7 +70,7 @@ If set, the swarm process will suspend on start and open a debugger on this port
 [cols="1,2a"]
 |===
 |Property
-|_none_
+|`swarm.debug.port`
 
 |Default
 |
@@ -114,14 +114,14 @@ fractionDetectMode::
 --
 The mode of fraction detection. The available options are:
 
-* `when_missing`: Runs only when no WildFly Swarm dependencies are found.
+* `when_missing`: Runs only when no {Thorntail} dependencies are found.
 * `force`: Always run, and merge any detected fractions with the existing dependencies. Existing dependencies take precedence.
 * `never`: Disable fraction detection.
 
 [cols="1,2a"]
 |===
 |Property
-|`swarm.fractionDetectMode`
+|`swarm.detect.mode`
 
 |Default
 |`when_missing`
@@ -143,7 +143,7 @@ The format of specifying a fraction can be:
 
 If no group is provided, `org.wildfly.swarm` is assumed.
 
-If no version is provided, the version is taken from the WildFly Swarm BOM for the version of the plugin you are using.
+If no version is provided, the version is taken from the {Thorntail} BOM for the version of the plugin you are using.
 
 [cols="1,2a"]
 |===
@@ -287,7 +287,7 @@ This JAR is not created automatically, so make sure you execute the `package` go
 [cols="1,2a"]
 |===
 |Property
-|`swarm.useUberJar`
+|`wildfly-swarm.useUberJar`
 
 |Default
 |false

--- a/docs/topics/wildfly-swarm/docs/reference/pom.xml
+++ b/docs/topics/wildfly-swarm/docs/reference/pom.xml
@@ -4,8 +4,7 @@
   ~
   ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
   -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.wildfly.swarm.docs</groupId>
@@ -14,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>7.0.1</version>
+    <version>7.1.0</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/docs/topics/wildfly-swarm/docs/reference/usage.adoc
+++ b/docs/topics/wildfly-swarm/docs/reference/usage.adoc
@@ -1,6 +1,6 @@
 = The `usage.txt` file
 
-Each WildFly Swarm application can contain a text file with usage instructions at one of the following locations:
+Each {Thorntail} application can contain a text file with usage instructions at one of the following locations:
 
 * `/usage.txt`
 * `/META-INF/usage.txt`

--- a/scripts/sync_with_wildfly_swarm.sh
+++ b/scripts/sync_with_wildfly_swarm.sh
@@ -5,7 +5,7 @@ TEMP_DIR="$(mktemp -d)"                                                     # Te
 
 REPO_NAME="wildfly-swarm"                                                   # Repository base name, and the directory name on the disk
 REPO_URL="git@github.com:wildfly-swarm-prod/${REPO_NAME}.git"               # Repo Git URL
-REPO_BRANCH="7.0.x"                                                         # Branch to be synchronized
+REPO_BRANCH="7.1.x"                                                         # Branch to be synchronized
 MAVEN_SETTINGS_URL="https://github.com/wildfly-swarm-prod/wildfly-swarm-repository/blob/master/debug-utils/settingsForLocalM2.xml" # Maven settings to use when building
 
 FILES_LIST="${SCRIPT_SRC}/wildfly-swarm-files.txt"                          # File with file- or directory names to synchronize


### PR DESCRIPTION
This is the full sync of the WFS 7.1 sources before release.

Notable changes:

* The sync branch in the script as been bumped to `7.1.x`, obviously.
* The `WildFly Swarm` string in the docs has been replaced with the `{Thorntail}` attribute pending the rename (currently, the attribute is set to `WildFly Swarm`)
* The WFS product version has been bumped to `7.1.0.redhat-77`
* The community documentation that we link to in _Additional resources_ has been bumped to version `2018.3.3`. The structure of the upstream docs has changed since `2017.10.0`, so there is only one book now.
* There are several new files in the docs. Not all of them are used in the launcher docs, so do not be alarmed by their very existence.

Resolves RHOARDOC-1228.