### PR TITLE
follow-up to RHAORDOC-1298

### DIFF
--- a/docs/topics/proc_configuring-your-vertx-application-to-use-agroal.adoc
+++ b/docs/topics/proc_configuring-your-vertx-application-to-use-agroal.adoc
@@ -2,19 +2,19 @@
 = Configuring your {VertX} application to use Agroal
 
 // hard-coded version, beacuse it does not change
-Starting with {ProductShortName} {VertX} release `3.5.1.redhat-003`, Agroal is the default JDBC connection pool, replacing c3p0 used as the default option in previous releases.
-Due to differences in property names between c3p0 and Agroal, upgrading to a newer release of {ProductShortName} {VertX} might break the JDBC client configuration of your existing {VertX} applications.
-Update the property names in the configuration of your JDBC client to avoid this issue.
+Starting with {VertX} release `3.5.1.redhat-003`, Agroal is the default JDBC connection pool, replacing C3P0 used as the default option in previous releases.
+Due to differences in property names between C3P0 and Agroal, upgrading to a newer release of {VertX} might break the JDBC connection pool configuration of your existing {VertX} applications.
+Update the property names in the configuration of your JDBC connection pool to avoid this issue.
 
-NOTE: To continue using c3p0 as the JDBC client for your application, set the value of the `provider_class` property in your JDBC client configuration to `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider`.
+NOTE: To continue using C3P0 as the JDBC connection pool for your application, set the value of the `provider_class` property in your JDBC connection pool configuration to `io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider`.
 
 .Procedure
 
-. Update the following property names within your JDBC client configuration to match the client you use:
+. Update the following property names within your JDBC connection pool configuration to match the connection pool you use:
 
 [options="header"]
 |===
-| c3p0 property name | Agroal property name
+| C3P0 property name | Agroal property name
 | url | jdbcUrl
 | driver_class | driverClassName
 | user | principal
@@ -24,19 +24,21 @@ NOTE: To continue using c3p0 as the JDBC client for your application, set the va
 
 .Additional information
 
-* Example JDBC client configuration using c3p0:
+* Example JDBC connection pool configuration using C3P0:
 +
 [source,java,options="nowrap"]
 --
 JsonObject config = new JsonObject()
 	.put("url", JDBC_URL)
+	// set C3P0 as the JDBC connection pool:
+	.put("provider_class", "io.vertx.ext.jdbc.spi.impl.C3P0DataSourceProvider")
 	.put("driver_class", "org.postgresql.Driver")
 	.put("user", JDBC_USER)
 	.put("password", JDBC_PASSWORD)
 	.put("castUUID", true);
 --
 
-* Example JDBC client configuration using Agroal:
+* Example JDBC connection pool configuration using Agroal:
 +
 [source,java,options="nowrap"]
 --


### PR DESCRIPTION
* included property to explicitly set C3P0 as the data source provider in the C3P0 config example
* added comment to the C3P0 example to show where the extra property is set
* minor wording fixes: (c3p0 ->  C3P0) + a few others
* hardcoded _RHOAR_ as the product short name since `{ProductShortName}` maps to upstream name