### PR TITLE
RHOARDOC-1179: Added file with commit hash to be synced

### DIFF
--- a/docs/topics/proc_syncing-with-wildflyswarm-docs.adoc
+++ b/docs/topics/proc_syncing-with-wildflyswarm-docs.adoc
@@ -13,6 +13,8 @@ The variables are documented in the script.
 
 Some files are not present in the upstream repository because they are generated. The script automatically builds the upstream project with Maven, ensuring these files are not missing.
 
+The hash of the synced upstream commit is stored in the `docs/topics/wildfly-swarm/docs/commit.hash` file.
+
 [discrete]
 == Prerequisites
 

--- a/scripts/wildfly-swarm-files.txt
+++ b/scripts/wildfly-swarm-files.txt
@@ -3,3 +3,4 @@
 docs/howto
 docs/concepts
 docs/reference
+docs/commit.hash


### PR DESCRIPTION
Resolves RHOARDOC-1179

I haven't synced the current sources because it would overwrite some of our hotfixes. The next version of the upstream sources does contain them.