### PR TITLE
fixes RHAORDOC-1375

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -97,11 +97,11 @@
 :WildFlySwarmVersion: 2018.3.3
 
 // spring boot version for rt guide
-:SpringBootVersion: 1.5.13.RELEASE
+:SpringBootVersion: 1.5.14.RELEASE
 
 //used in BOM file example
-:SpringBootBOMVersion: 1.5.13.Final-redhat-3
-:SpringBootMvnPluginVersion: 1.5.13.RELEASE
+:SpringBootBOMVersion: 1.5.14.Final-redhat-1
+:SpringBootMvnPluginVersion: 1.5.14.RELEASE
 
 // used in the BOM file example and in the Vert.x Runtime developer Guide
 :VertXVersion: 3.5.1.redhat-004


### PR DESCRIPTION
updated Spring boot and spring Boot Maven plugin version in the run time guides for the `1.5.14` release.