### PR TITLE
update proc_installing-launcher-tool-addon.adoc with 4 GB memory tip

### DIFF
--- a/docs/topics/proc_installing-launcher-tool-addon.adoc
+++ b/docs/topics/proc_installing-launcher-tool-addon.adoc
@@ -15,6 +15,14 @@ link:https://docs.openshift.org/latest/minishift/using/addons.html[Add-ons] enab
 
 .Procedure
 
+. Ensure you are running a minishift instance which has at least 4 GB memory to run launcher
++
+[source,bash,options="nowrap",subs="attributes+"]
+----
+$ minishift config set memory 8192
+$ minishift start
+----
+
 . Download and install the {launcher} add-on.
 +
 [source,bash,options="nowrap",subs="attributes+"]


### PR DESCRIPTION
as noted on both https://github.com/minishift/minishift-addons/tree/master/add-ons/fabric8-launcher and https://launcher.fabric8.io/docs/minishift-installation.html#install-launcher-app (currently, that page may change; see https://github.com/fabric8-launcher/launcher-openshift-templates/issues/2)