### PR TITLE
RHOARDOC-1403: Rename confusing runtime variables

### DIFF
--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -7,7 +7,7 @@ include::topics/templates/document-attributes.adoc[]
 :runtime: {Node}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:
-:node-js:
+:built-for-nodejs:
 
 :context: nodejs
 

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -1,7 +1,7 @@
 include::topics/templates/document-attributes.adoc[]
 //override for a cleaner TOC
 :toclevels: 2
-:spring-boot:
+:built-for-spring-boot:
 
 = {spring-boot-runtime-guide-name}
 :runtime: {SpringBoot}

--- a/docs/topics/assembly_authenticating-to-the-secured-booster-api-endpoint.adoc
+++ b/docs/topics/assembly_authenticating-to-the-secured-booster-api-endpoint.adoc
@@ -11,9 +11,9 @@ include::proc_getting-the-secured-booster-api-endpoint.adoc[leveloffset=+1]
 
 include::proc_authenticating-http-requests-using-the-command-line.adoc[leveloffset=+1]
 
-ifdef::node-js[:node-js-sso-temp-workaround:]
+ifdef::built-for-nodejs[:node-js-sso-temp-workaround:]
 include::proc_authenticating-http-requests-using-the-web-interface.adoc[leveloffset=+1]
-ifdef::node-js[:node-js-sso-temp-workaround!:]
+ifdef::built-for-nodejs[:node-js-sso-temp-workaround!:]
 
 :context: {parent-context}
 

--- a/docs/topics/assembly_cache-mission-booster.adoc
+++ b/docs/topics/assembly_cache-mission-booster.adoc
@@ -34,7 +34,7 @@ include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffs
 
 include::proc_interacting-with-the-unmodified-cache-booster.adoc[leveloffset=+1]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 :parameter-mission-name!:

--- a/docs/topics/assembly_circuit-breaker-mission-booster.adoc
+++ b/docs/topics/assembly_circuit-breaker-mission-booster.adoc
@@ -31,7 +31,7 @@ include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffs
 
 include::proc_interacting-with-the-circuit-breaker-booster.adoc[leveloffset=+1]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]
 
 include::proc_using-hystrix-dashboard-to-monitor-the-circuit-breaker.adoc[leveloffset=+1]

--- a/docs/topics/assembly_configmap-mission-booster.adoc
+++ b/docs/topics/assembly_configmap-mission-booster.adoc
@@ -34,7 +34,7 @@ include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffs
 include::proc_interacting-with-the-unmodified-configmap-booster-for-{parameter-runtime}.adoc[leveloffset=+1]
 :parameter-mission!:
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 :parameter-configmap:
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]
 :parameter-configmap!:

--- a/docs/topics/assembly_crud-mission-booster.adoc
+++ b/docs/topics/assembly_crud-mission-booster.adoc
@@ -36,9 +36,9 @@ This updates the name of the item with the given ID to match the name specified 
 This removes the item with the specified ID from the database and returns an HTTP code `204` (No Content) as a response.
 If you pass in an invalid ID, the call results in an HTTP error `404`.
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 This booster also contains a set of automated xref:running-the-booster-integration-tests_{context}[integration tests] that can be used to verify that the application is fully integrated with the database.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 This booster does not showcase a fully matured RESTful model (level 3), but it does use compatible HTTP verbs and status, following the recommended HTTP API practices.
 
@@ -55,11 +55,11 @@ include::assembly_deploying-the-booster-to-openshiftlocal.adoc[leveloffset=+1]
 
 include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffset=+1]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 include::proc_interacting-with-the-crud-api-on-node.adoc[leveloffset=+1]
 endif::[]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 include::proc_interacting-with-the-crud-api.adoc[leveloffset=+1]
 
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]

--- a/docs/topics/assembly_health-check-mission-booster.adoc
+++ b/docs/topics/assembly_health-check-mission-booster.adoc
@@ -38,9 +38,9 @@ include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffs
 
 include::proc_interacting-with-the-unmodified-health-check-booster.adoc[leveloffset=+1]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]
-endif::node-js[]
+endif::built-for-nodejs[]
 :parameter-mission-name!:
 
 include::ref_health-check-resources.adoc[leveloffset=+1]

--- a/docs/topics/assembly_http-api-mission-booster.adoc
+++ b/docs/topics/assembly_http-api-mission-booster.adoc
@@ -33,7 +33,7 @@ include::proc_deploying-the-booster-to-openshiftcontainerplatform.adoc[leveloffs
 
 include::proc_interacting-with-the-unmodified-http-api-booster-for-{parameter-runtime}.adoc[leveloffset=+1]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 include::proc_running-the-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 :parameter-mission-name!:

--- a/docs/topics/assembly_secured-mission-booster.adoc
+++ b/docs/topics/assembly_secured-mission-booster.adoc
@@ -43,7 +43,7 @@ include::assembly_deploying-the-secured-booster-to-openshiftcontainerplatform.ad
 
 include::assembly_authenticating-to-the-secured-booster-api-endpoint.adoc[leveloffset=+1]
 
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 include::proc_running-the-vertx-secured-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 

--- a/docs/topics/assembly_secured-mission-booster.adoc
+++ b/docs/topics/assembly_secured-mission-booster.adoc
@@ -47,7 +47,7 @@ ifdef::vert-x[]
 include::proc_running-the-vertx-secured-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 include::proc_running-the-springboot-secured-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 

--- a/docs/topics/assembly_secured-mission-booster.adoc
+++ b/docs/topics/assembly_secured-mission-booster.adoc
@@ -51,7 +51,7 @@ ifdef::built-for-spring-boot[]
 include::proc_running-the-springboot-secured-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 include::proc_running-the-wildflyswarm-secured-booster-integration-tests.adoc[leveloffset=+1]
 endif::[]
 

--- a/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
+++ b/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
@@ -70,7 +70,7 @@ ifdef::built-for-spring-boot[]
 i.o.booster.service.GreetingEndpoint     : Message: Hello, Sarah!
 ----
 endif::[]
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 [source,options="nowrap",subs="attributes+"]
 ----
 ...
@@ -92,7 +92,7 @@ endif::[]
 ifdef::built-for-spring-boot[]
 . To disable debug logging, remove `logging.level.fully.qualified.name.of.TheClass=DEBUG` from `src/main/resources/application.properties` and redeploy your application.
 endif::[]
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 . To disable debug logging, update your logging configuration file, for example `src/main/resources/vertx-default-jul-logging.properties`, remove the logging configuration for your class and redeploy your application.
 endif::[]
 ifdef::wf-swarm[]

--- a/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
+++ b/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
@@ -79,7 +79,7 @@ INFO: Greeting: Hello, Sarah
 ...
 ----
 endif::[]
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 [source,options="nowrap",subs="attributes+"]
 ----
 ...
@@ -95,11 +95,11 @@ endif::[]
 ifdef::built-for-vertx[]
 . To disable debug logging, update your logging configuration file, for example `src/main/resources/vertx-default-jul-logging.properties`, remove the logging configuration for your class and redeploy your application.
 endif::[]
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 . To disable debug logging, remove the `logging` key from the `project-defaults.yml` file and redeploy the appliation.
 endif::[]
 
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 [discrete]
 == Additional resources
 

--- a/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
+++ b/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
@@ -64,7 +64,7 @@ $ curl $APPLICATION_ROUTE/api/greeting?name=Sarah
 . Return to the window with your pod logs and inspect debug logging messages in the logs.
 +
 --
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [source,options="nowrap",subs="attributes+"]
 ----
 i.o.booster.service.GreetingEndpoint     : Message: Hello, Sarah!
@@ -89,7 +89,7 @@ ifdef::wf-swarm[]
 endif::[]
 --
 
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 . To disable debug logging, remove `logging.level.fully.qualified.name.of.TheClass=DEBUG` from `src/main/resources/application.properties` and redeploy your application.
 endif::[]
 ifdef::vert-x[]

--- a/docs/topics/proc_authenticating-http-requests-using-the-command-line.adoc
+++ b/docs/topics/proc_authenticating-http-requests-using-the-command-line.adoc
@@ -38,7 +38,7 @@ NOTE: The `-sk` option tells curl to ignore failures resulting from self-signed 
 --
 
 :service-path: api/greeting
-ifdef::vert-x[:service-path: greeting]
+ifdef::built-for-vertx[:service-path: greeting]
 
 . Invoke the {name-mission-secured} service. Attach the access (bearer) token to the HTTP headers:
 +

--- a/docs/topics/proc_creating-an-application.adoc
+++ b/docs/topics/proc_creating-an-application.adoc
@@ -37,7 +37,7 @@ $ cd myApp
 
 . Create a `pom.xml` file.
 +
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 [source,xml,options="nowrap",subs="attributes+"]
 ----
 include::resources/vert-x/vertx-starter-example-pom.xml[]
@@ -57,7 +57,7 @@ For example, for `<groupId>my.awesome.project</groupId>`, the location of the cl
 +
 .Example `src/main/java/com/example/MyApp.java`
 +
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 [source,java,options="nowrap",subs="attributes+"]
 ----
 include::resources/vert-x/vertxGreetingApp.java[]

--- a/docs/topics/proc_creating-an-application.adoc
+++ b/docs/topics/proc_creating-an-application.adoc
@@ -43,7 +43,7 @@ ifdef::vert-x[]
 include::resources/vert-x/vertx-starter-example-pom.xml[]
 ----
 endif::[]
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [source,xml,options="nowrap",subs="attributes+"]
 ----
 include::resources/spring-boot/spring-boot-starter-example-pom.xml[]
@@ -63,7 +63,7 @@ ifdef::vert-x[]
 include::resources/vert-x/vertxGreetingApp.java[]
 ----
 endif::[]
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [source,java,options="nowrap",subs="attributes+"]
 ----
 include::resources/spring-boot/springBootGreetingApp.java[]

--- a/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
@@ -20,7 +20,7 @@ You can easily deploy your existing application to OpenShift using the Fabric8 M
 
 . Add the following profile to the `pom.xml` file in the root directory of your application:
 +
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 [source,xml,options="nowrap",subs="attributes+"]
 ----
 include::resources/vert-x/vertx-openshift-pom-config-example.xml[]

--- a/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
@@ -26,7 +26,7 @@ ifdef::vert-x[]
 include::resources/vert-x/vertx-openshift-pom-config-example.xml[]
 ----
 endif::[]
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [source,xml,options="nowrap",subs="attributes+"]
 ----
 include::resources/spring-boot/spring-boot-openshift-pom-config-example.xml[]

--- a/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
@@ -45,23 +45,23 @@ $ oc new-project {project-name}
 $ oc apply -f service.cache.yml
 ----
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `start-openshift.sh` to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ ./start-openshift.sh
 ----
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift
 ----
-endif::node-js[]
+endif::built-for-nodejs[]
 
 . Check the status of your booster and ensure your pod is running.
 +

--- a/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
@@ -44,7 +44,7 @@ $ oc new-project {project-name}
 
 . Navigate to the root directory of your booster.
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -53,9 +53,9 @@ $ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use the provided `start-openshift.sh` script to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -65,7 +65,7 @@ $ ./start-openshift.sh
 ----
 +
 These commands use the xref:about-nodeshift[Nodeshift] `npm` module to install your dependencies, launch the S2I build process on OpenShift, and start the services.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 
 . Check the status of your booster and ensure your pod is running.

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -43,14 +43,14 @@ $ unzip {project-name}.zip
 $ oc new-project {project-name}
 ----
 
-ifdef::vert-x,spring-boot,built-for-nodejs[]
+ifdef::vert-x,built-for-spring-boot,built-for-nodejs[]
 . Assign view access rights to the service account before deploying your booster, so that the booster can access the OpenShift API in order to read the contents of the ConfigMap.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::vert-x,spring-boot,built-for-nodejs[]
+endif::vert-x,built-for-spring-boot,built-for-nodejs[]
 
 . Navigate to the root directory of your booster.
 
@@ -98,7 +98,7 @@ data:
 ...
 ----
 endif::wf-swarm[]
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 . Deploy your ConfigMap configuration to OpenShift using `application.yml`.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -120,17 +120,17 @@ data:
        message: "Hello %s from a ConfigMap!"
 ...
 ----
-endif::spring-boot[]
+endif::built-for-spring-boot[]
 
 ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
-ifdef::vert-x,spring-boot[]
+ifdef::vert-x,built-for-spring-boot[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift
 ----
-endif::vert-x,spring-boot[]
+endif::vert-x,built-for-spring-boot[]
 ifdef::wf-swarm[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -76,7 +76,7 @@ data:
 ...
 ----
 endif::built-for-vertx,built-for-nodejs[]
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 . Deploy your ConfigMap configuration to OpenShift using `app-config.yml` in the root of the booster.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -97,7 +97,7 @@ data:
       message: Hello %s from a ConfigMap!
 ...
 ----
-endif::wf-swarm[]
+endif::built-for-thorntail[]
 ifdef::built-for-spring-boot[]
 . Deploy your ConfigMap configuration to OpenShift using `application.yml`.
 +
@@ -131,12 +131,12 @@ ifdef::built-for-vertx,built-for-spring-boot[]
 $ mvn clean fabric8:deploy -Popenshift
 ----
 endif::built-for-vertx,built-for-spring-boot[]
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift -DskipTests
 ----
-endif::wf-swarm[]
+endif::built-for-thorntail[]
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
 endif::built-for-nodejs[]

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -43,18 +43,18 @@ $ unzip {project-name}.zip
 $ oc new-project {project-name}
 ----
 
-ifdef::vert-x,spring-boot,node-js[]
+ifdef::vert-x,spring-boot,built-for-nodejs[]
 . Assign view access rights to the service account before deploying your booster, so that the booster can access the OpenShift API in order to read the contents of the ConfigMap.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::vert-x,spring-boot,node-js[]
+endif::vert-x,spring-boot,built-for-nodejs[]
 
 . Navigate to the root directory of your booster.
 
-ifdef::vert-x,node-js[]
+ifdef::vert-x,built-for-nodejs[]
 . Deploy your ConfigMap configuration to OpenShift using `app-config.yml`.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -75,7 +75,7 @@ data:
       level : INFO
 ...
 ----
-endif::vert-x,node-js[]
+endif::vert-x,built-for-nodejs[]
 ifdef::wf-swarm[]
 . Deploy your ConfigMap configuration to OpenShift using `app-config.yml` in the root of the booster.
 +
@@ -122,7 +122,7 @@ data:
 ----
 endif::spring-boot[]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
 ifdef::vert-x,spring-boot[]
@@ -139,9 +139,9 @@ $ mvn clean fabric8:deploy -Popenshift -DskipTests
 endif::wf-swarm[]
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `npm` to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -150,7 +150,7 @@ $ npm install && npm run openshift
 ----
 +
 These commands install any missing module dependencies, then using the xref:about-nodeshift[Nodeshift] module, deploy the booster on OpenShift.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 . Check the status of your booster and ensure your pod is running.
 +

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -43,18 +43,18 @@ $ unzip {project-name}.zip
 $ oc new-project {project-name}
 ----
 
-ifdef::vert-x,built-for-spring-boot,built-for-nodejs[]
+ifdef::built-for-vertx,built-for-spring-boot,built-for-nodejs[]
 . Assign view access rights to the service account before deploying your booster, so that the booster can access the OpenShift API in order to read the contents of the ConfigMap.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::vert-x,built-for-spring-boot,built-for-nodejs[]
+endif::built-for-vertx,built-for-spring-boot,built-for-nodejs[]
 
 . Navigate to the root directory of your booster.
 
-ifdef::vert-x,built-for-nodejs[]
+ifdef::built-for-vertx,built-for-nodejs[]
 . Deploy your ConfigMap configuration to OpenShift using `app-config.yml`.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -75,7 +75,7 @@ data:
       level : INFO
 ...
 ----
-endif::vert-x,built-for-nodejs[]
+endif::built-for-vertx,built-for-nodejs[]
 ifdef::wf-swarm[]
 . Deploy your ConfigMap configuration to OpenShift using `app-config.yml` in the root of the booster.
 +
@@ -125,12 +125,12 @@ endif::built-for-spring-boot[]
 ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
-ifdef::vert-x,built-for-spring-boot[]
+ifdef::built-for-vertx,built-for-spring-boot[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ mvn clean fabric8:deploy -Popenshift
 ----
-endif::vert-x,built-for-spring-boot[]
+endif::built-for-vertx,built-for-spring-boot[]
 ifdef::wf-swarm[]
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -163,9 +163,9 @@ NAME                                       READY     STATUS      RESTARTS   AGE
 ----
 +
 The `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 You should also wait for your pod to be _ready_ before proceeding, which is shown in the `READY` column. For example, `{app-name}-1-aaaaa` is _ready_ when the `READY` column is `1/1`.
-endif::vert-x[]
+endif::built-for-vertx[]
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.

--- a/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
@@ -70,7 +70,7 @@ The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
 
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use maven to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -79,9 +79,9 @@ $ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `npm` to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -90,7 +90,7 @@ $ npm install && npm run openshift
 ----
 +
 These commands install any missing module dependencies, then using the xref:about-nodeshift[Nodeshift] module, deploy the booster on OpenShift.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 . Check the status of your booster and ensure your pod is running.
 +

--- a/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
@@ -43,7 +43,7 @@ $ oc new-project {project-name}
 
 . Navigate to the root directory of your booster.
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -52,9 +52,9 @@ $ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `npm` to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -63,7 +63,7 @@ $ npm install && npm run openshift
 ----
 +
 These commands install any missing module dependencies, then using the xref:about-nodeshift[Nodeshift] module, deploy the booster on OpenShift.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 . Check the status of your booster and ensure your pod is running.
 +

--- a/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
@@ -44,7 +44,7 @@ $ oc new-project {project-name}
 
 . Navigate to the root directory of your booster.
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -53,9 +53,9 @@ $ mvn clean fabric8:deploy -Popenshift
 ----
 +
 This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}[S2I process] on OpenShift and to start the pod.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `npm` to start the deployment to OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
@@ -64,7 +64,7 @@ $ npm install && npm run openshift
 ----
 +
 These commands install any missing module dependencies, then using the xref:about-nodeshift[Nodeshift] module, deploy the booster on OpenShift.
-endif::node-js[]
+endif::built-for-nodejs[]
 
 . Check the status of your booster and ensure your pod is running.
 +

--- a/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
@@ -48,7 +48,7 @@ $ oc new-project {project-name}
 $ oc create -f service.sso.yaml
 ----
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 . Use Maven to start the deployment to {parameter-deployment}.
 +
 --
@@ -62,9 +62,9 @@ This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}
 --
 
 This process generates the uberjar file as well as the OpenShift resources and deploys them to the current project on your {parameter-deployment} server.
-endif::node-js[]
+endif::built-for-nodejs[]
 
-ifdef::node-js[]
+ifdef::built-for-nodejs[]
 . Use `npm` to start the deployment to {parameter-deployment}.
 +
 --
@@ -76,4 +76,4 @@ $ npm install && npm run openshift -- \
 
 These commands install any missing module dependencies, then using the xref:about-nodeshift[Nodeshift] module, deploy the booster on OpenShift.
 --
-endif::node-js[]
+endif::built-for-nodejs[]

--- a/docs/topics/proc_interacting-with-the-circuit-breaker-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-circuit-breaker-booster.adoc
@@ -43,7 +43,7 @@ If the remote endpoint is unavailable, the `name` service responds with an HTTP 
 The state can be:
 ** _open_ : the circuit breaker is preventing requests from reaching the failed service,
 ** _closed_: the circuit breaker is allowing requests to reach the service.
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 ** _half-open_: the circuit breaker is allowing a request to reach the service. If the request succeeds, the state of the service is reset to closed. If the request fails, the timer is restarted.
 endif::[]
 

--- a/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
@@ -5,7 +5,7 @@ Once you have the booster deployed, you will have a service called `{app-name}` 
 
 /api/greeting::
 ifdef::built-for-vertx,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
-ifdef::built-for-spring-boot,wf-swarm[Returns a name as a String.]
+ifdef::built-for-spring-boot,built-for-thorntail[Returns a name as a String.]
 
 /api/stop::
 Forces the service to become unresponsive as means to simulate a failure.
@@ -81,7 +81,7 @@ ifdef::built-for-spring-boot[]
 ----
 endif::[]
 
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 ----
 <html>
   <head><title>Error</title></head>

--- a/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
@@ -4,7 +4,7 @@
 Once you have the booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
 
 /api/greeting::
-ifdef::vert-x,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
+ifdef::built-for-vertx,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
 ifdef::built-for-spring-boot,wf-swarm[Returns a name as a String.]
 
 /api/stop::
@@ -43,7 +43,7 @@ ifdef::built-for-spring-boot[an `Application is not available` page.]
 $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/stop
 ----
 
-ifdef::vert-x,built-for-nodejs[]
+ifdef::built-for-vertx,built-for-nodejs[]
 [source,option="nowrap",subs="attributes+"]
 ----
 Stopping HTTP server, Bye bye world !
@@ -58,7 +58,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 ----
 
 // Responses vary wildly among runtimes
-ifdef::vert-x,built-for-nodejs[]
+ifdef::built-for-vertx,built-for-nodejs[]
 [source,option="nowrap",subs="attributes+"]
 ----
 Not online

--- a/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
@@ -5,7 +5,7 @@ Once you have the booster deployed, you will have a service called `{app-name}` 
 
 /api/greeting::
 ifdef::vert-x,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
-ifdef::spring-boot,wf-swarm[Returns a name as a String.]
+ifdef::built-for-spring-boot,wf-swarm[Returns a name as a String.]
 
 /api/stop::
 Forces the service to become unresponsive as means to simulate a failure.
@@ -35,8 +35,8 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 --
 Invoking the `/api/stop` endpoint simulates an internal service failure and triggers the OpenShift self-healing capabilities.
 When invoking `/api/greeting` after simulating the failure, the service should return
-ifndef::spring-boot[a HTTP status `503`.]
-ifdef::spring-boot[an `Application is not available` page.]
+ifndef::built-for-spring-boot[a HTTP status `503`.]
+ifdef::built-for-spring-boot[an `Application is not available` page.]
 
 [source,bash,option="nowrap",subs="attributes+"]
 ----
@@ -65,7 +65,7 @@ Not online
 ----
 endif::[]
 
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 ----
 <html>
   <head>
@@ -90,7 +90,7 @@ ifdef::wf-swarm[]
 ----
 endif::[]
 
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [NOTE]
 ====
 Depending on when OpenShift removes the pod after you invoke the `/api/stop` endpoint, you might initially see a 404 error code.

--- a/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
@@ -4,7 +4,7 @@
 Once you have the booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
 
 /api/greeting::
-ifdef::vert-x,node-js[Returns a JSON containing greeting of `name` parameter (or World as default value).]
+ifdef::vert-x,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
 ifdef::spring-boot,wf-swarm[Returns a name as a String.]
 
 /api/stop::
@@ -43,7 +43,7 @@ ifdef::spring-boot[an `Application is not available` page.]
 $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/stop
 ----
 
-ifdef::vert-x,node-js[]
+ifdef::vert-x,built-for-nodejs[]
 [source,option="nowrap",subs="attributes+"]
 ----
 Stopping HTTP server, Bye bye world !
@@ -58,7 +58,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 ----
 
 // Responses vary wildly among runtimes
-ifdef::vert-x,node-js[]
+ifdef::vert-x,built-for-nodejs[]
 [source,option="nowrap",subs="attributes+"]
 ----
 Not online

--- a/docs/topics/proc_running-the-booster-integration-tests.adoc
+++ b/docs/topics/proc_running-the-booster-integration-tests.adoc
@@ -24,14 +24,14 @@ include::note-integration-tests-app-deletion-warning.adoc[]
 * an empty OpenShift project
 
 ifdef::parameter-configmap[]
-ifdef::vert-x,built-for-spring-boot[]
+ifdef::built-for-vertx,built-for-spring-boot[]
 * view access permission assigned to the service account of your booster application. This allows your application to read the configuration from the ConfigMap:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::vert-x,built-for-spring-boot[]
+endif::built-for-vertx,built-for-spring-boot[]
 endif::parameter-configmap[]
 
 [discrete]

--- a/docs/topics/proc_running-the-booster-integration-tests.adoc
+++ b/docs/topics/proc_running-the-booster-integration-tests.adoc
@@ -24,14 +24,14 @@ include::note-integration-tests-app-deletion-warning.adoc[]
 * an empty OpenShift project
 
 ifdef::parameter-configmap[]
-ifdef::vert-x,spring-boot[]
+ifdef::vert-x,built-for-spring-boot[]
 * view access permission assigned to the service account of your booster application. This allows your application to read the configuration from the ConfigMap:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 $ oc policy add-role-to-user view -n $(oc project -q) -z default
 ----
-endif::vert-x,spring-boot[]
+endif::vert-x,built-for-spring-boot[]
 endif::parameter-configmap[]
 
 [discrete]

--- a/docs/topics/proc_running-the-springboot-secured-booster-integration-tests.adoc
+++ b/docs/topics/proc_running-the-springboot-secured-booster-integration-tests.adoc
@@ -30,7 +30,7 @@ oc create -f service.sso.yaml
 --
 +
 . Wait until the {RHSSO} server is ready. Go to the Web console or view the output of `oc get pods` to check if the pod running the {RHSSO} server is ready.
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 +
 . Deploy the Secured HTTP API application:
 +
@@ -40,7 +40,7 @@ mvn fabric8:deploy -Popenshift
 --
 +
 . Wait until the Secured HTTP API is ready. Go to the Web console or view the output of `oc get pods` to check if the pod running the HTTP API endpoint is ready.
-endif::vert-x[]
+endif::built-for-vertx[]
 +
 // ifdef::secured-spring-boot-mission[]
 // +

--- a/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
@@ -13,7 +13,7 @@ One of the ways of debugging a Maven-based project is manually launching the app
 This method is applicable at least to the following deployments of the application:
 
 ifdef::built-for-vertx[* When launching the application manually using the `mvn {parameter-maven-goal}` goal. This starts the application with debugging enabled.]
-ifdef::wf-swarm[]
+ifdef::built-for-thorntail[]
 * When launching the application manually using the `mvn {parameter-maven-goal}` goal.
 * When starting the application without waiting for it to exit using the `mvn wildfly-swarm:start` goal.
 This is useful especially when performing integration testing.

--- a/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-locally-in-debugging-mode.adoc
@@ -12,7 +12,7 @@
 One of the ways of debugging a Maven-based project is manually launching the application while specifying a debugging port, and subsequently connecting a remote debugger to that port.
 This method is applicable at least to the following deployments of the application:
 
-ifdef::vert-x[* When launching the application manually using the `mvn {parameter-maven-goal}` goal. This starts the application with debugging enabled.]
+ifdef::built-for-vertx[* When launching the application manually using the `mvn {parameter-maven-goal}` goal. This starts the application with debugging enabled.]
 ifdef::wf-swarm[]
 * When launching the application manually using the `mvn {parameter-maven-goal}` goal.
 * When starting the application without waiting for it to exit using the `mvn wildfly-swarm:start` goal.
@@ -40,6 +40,6 @@ $ mvn {parameter-maven-goal} -D{parameter-debug-property}=$PORT_NUMBER
 Here, `$PORT_NUMBER` is an unused port number of your choice.
 Remember this number for the remote debugger configuration.
 
-ifdef::vert-x[Use the `-Ddebug.suspend=true` argument to make the application wait until a debugger is attached to start.]
+ifdef::built-for-vertx[Use the `-Ddebug.suspend=true` argument to make the application wait until a debugger is attached to start.]
 --
 

--- a/docs/topics/proc_using-hystrix-dashboard-to-monitor-the-circuit-breaker.adoc
+++ b/docs/topics/proc_using-hystrix-dashboard-to-monitor-the-circuit-breaker.adoc
@@ -61,13 +61,13 @@ Alternatively, you can navigate to the _Overview_ screen in the Web console and 
 . To use the Dashboard to monitor the `{app-name}-greeting` service, replace the default event stream address with the following address and click the _Monitor Stream_ button.
 +
 --
-ifdef::spring-boot[]
+ifdef::built-for-spring-boot[]
 [source,subs="attributes+",options="nowrap"]
 ----
 http://{app-name}-greeting-{project-name}.{osl-route-hostname}/hystrix.stream
 ----
 endif::[]
-ifndef::spring-boot[]
+ifndef::built-for-spring-boot[]
 [source,subs="attributes+",options="nowrap"]
 ----
 http://{app-name}-greeting/hystrix.stream

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -6,7 +6,7 @@ More background and related information on caching can be found here:
 
 ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-mission-cache} Mission - {SpringBoot} Booster]]
 
-ifndef::vert-x[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - {VertX} Booster]]
+ifndef::built-for-vertx[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - {VertX} Booster]]
 
 ifndef::wf-swarm[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} Mission - {WildFlySwarm} Booster]]
 

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -4,7 +4,7 @@
 
 More background and related information on caching can be found here:
 
-ifndef::spring-boot[* link:{link-mission-cache-spring-boot}[{name-mission-cache} Mission - {SpringBoot} Booster]]
+ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-mission-cache} Mission - {SpringBoot} Booster]]
 
 ifndef::vert-x[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - {VertX} Booster]]
 

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -8,7 +8,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-miss
 
 ifndef::built-for-vertx[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - {VertX} Booster]]
 
-ifndef::wf-swarm[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} Mission - {WildFlySwarm} Booster]]
+ifndef::built-for-thorntail[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} Mission - {WildFlySwarm} Booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-cache-nodejs}[{name-mission-cache} Mission - {Node} Booster]]
 

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -10,5 +10,5 @@ ifndef::vert-x[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - 
 
 ifndef::wf-swarm[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} Mission - {WildFlySwarm} Booster]]
 
-ifndef::node-js[* link:{link-mission-cache-nodejs}[{name-mission-cache} Mission - {Node} Booster]]
+ifndef::built-for-nodejs[* link:{link-mission-cache-nodejs}[{name-mission-cache} Mission - {Node} Booster]]
 

--- a/docs/topics/ref_circuit-breaker-resources.adoc
+++ b/docs/topics/ref_circuit-breaker-resources.adoc
@@ -15,9 +15,9 @@ ifndef::built-for-vertx[]
 * link:{link-mission-circuit-breaker-vertx}[{mission-circuit-breaker-vertx-guide-name}]
 endif::built-for-vertx[]
 
-ifndef::wf-swarm[]
+ifndef::built-for-thorntail[]
 * link:{link-mission-circuit-breaker-wf-swarm}[{mission-circuit-breaker-wf-swarm-guide-name}]
-endif::wf-swarm[]
+endif::built-for-thorntail[]
 
 ifndef::built-for-nodejs[]
 * link:{link-mission-circuit-breaker-nodejs}[{mission-circuit-breaker-nodejs-guide-name}]

--- a/docs/topics/ref_circuit-breaker-resources.adoc
+++ b/docs/topics/ref_circuit-breaker-resources.adoc
@@ -19,6 +19,6 @@ ifndef::wf-swarm[]
 * link:{link-mission-circuit-breaker-wf-swarm}[{mission-circuit-breaker-wf-swarm-guide-name}]
 endif::wf-swarm[]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
 * link:{link-mission-circuit-breaker-nodejs}[{mission-circuit-breaker-nodejs-guide-name}]
-endif::node-js[]
+endif::built-for-nodejs[]

--- a/docs/topics/ref_circuit-breaker-resources.adoc
+++ b/docs/topics/ref_circuit-breaker-resources.adoc
@@ -7,9 +7,9 @@ Follow the links below for more background information on the design principles 
 
 * link:https://martinfowler.com/bliki/CircuitBreaker.html[Martin Fowler: CircuitBreaker]
 
-ifndef::spring-boot[]
+ifndef::built-for-spring-boot[]
 * link:{link-mission-circuit-breaker-spring-boot}[{mission-circuit-breaker-spring-boot-guide-name}]
-endif::spring-boot[]
+endif::built-for-spring-boot[]
 
 ifndef::vert-x[]
 * link:{link-mission-circuit-breaker-vertx}[{mission-circuit-breaker-vertx-guide-name}]

--- a/docs/topics/ref_circuit-breaker-resources.adoc
+++ b/docs/topics/ref_circuit-breaker-resources.adoc
@@ -11,9 +11,9 @@ ifndef::built-for-spring-boot[]
 * link:{link-mission-circuit-breaker-spring-boot}[{mission-circuit-breaker-spring-boot-guide-name}]
 endif::built-for-spring-boot[]
 
-ifndef::vert-x[]
+ifndef::built-for-vertx[]
 * link:{link-mission-circuit-breaker-vertx}[{mission-circuit-breaker-vertx-guide-name}]
-endif::vert-x[]
+endif::built-for-vertx[]
 
 ifndef::wf-swarm[]
 * link:{link-mission-circuit-breaker-wf-swarm}[{mission-circuit-breaker-wf-swarm-guide-name}]

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -7,10 +7,10 @@ More background and related information on {name-mission-configmap} and ConfigMa
 * link:https://blog.openshift.com/configuring-your-application-part-1/[Blog Post about ConfigMap in OpenShift]
 
 ifdef::built-for-spring-boot[* link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Externalized Configuration with {SpringBoot}]]
-ifdef::vert-x[* link:http://vertx.io/docs/vertx-config/js/[Externalized Configuration with {VertX}]]
+ifdef::built-for-vertx[* link:http://vertx.io/docs/vertx-config/js/[Externalized Configuration with {VertX}]]
 ifdef::wf-swarm[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/v/eee1f5ba4dd4f13855cbe98addd365ba29033810/configuration/index.html[Externalized Configuration with {WildFlySwarm}]]
 ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
-ifndef::vert-x[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
+ifndef::built-for-vertx[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
 ifndef::wf-swarm[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
 ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]
 

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -8,9 +8,9 @@ More background and related information on {name-mission-configmap} and ConfigMa
 
 ifdef::built-for-spring-boot[* link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Externalized Configuration with {SpringBoot}]]
 ifdef::built-for-vertx[* link:http://vertx.io/docs/vertx-config/js/[Externalized Configuration with {VertX}]]
-ifdef::wf-swarm[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/v/eee1f5ba4dd4f13855cbe98addd365ba29033810/configuration/index.html[Externalized Configuration with {WildFlySwarm}]]
+ifdef::built-for-thorntail[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/v/eee1f5ba4dd4f13855cbe98addd365ba29033810/configuration/index.html[Externalized Configuration with {WildFlySwarm}]]
 ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
 ifndef::built-for-vertx[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
-ifndef::wf-swarm[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
+ifndef::built-for-thorntail[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
 ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]
 

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -12,5 +12,5 @@ ifdef::wf-swarm[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-gui
 ifndef::spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
 ifndef::vert-x[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
 ifndef::wf-swarm[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
-ifndef::node-js[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]
+ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]
 

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -6,10 +6,10 @@ More background and related information on {name-mission-configmap} and ConfigMa
 * link:https://docs.openshift.org/latest/dev_guide/configmaps.html[OpenShift ConfigMap Documentation]
 * link:https://blog.openshift.com/configuring-your-application-part-1/[Blog Post about ConfigMap in OpenShift]
 
-ifdef::spring-boot[* link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Externalized Configuration with {SpringBoot}]]
+ifdef::built-for-spring-boot[* link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Externalized Configuration with {SpringBoot}]]
 ifdef::vert-x[* link:http://vertx.io/docs/vertx-config/js/[Externalized Configuration with {VertX}]]
 ifdef::wf-swarm[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/v/eee1f5ba4dd4f13855cbe98addd365ba29033810/configuration/index.html[Externalized Configuration with {WildFlySwarm}]]
-ifndef::spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
+ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
 ifndef::vert-x[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
 ifndef::wf-swarm[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
 ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -12,9 +12,9 @@ ifndef::built-for-spring-boot[]
 * link:{link-mission-health-check-spring-boot}[Health Check - {SpringBoot} Booster]
 endif::built-for-spring-boot[]
 
-ifndef::vert-x[]
+ifndef::built-for-vertx[]
 * link:{link-mission-health-check-vertx}[Health Check - {VertX} Booster]
-endif::vert-x[]
+endif::built-for-vertx[]
 
 ifndef::wf-swarm[]
 * link:{link-mission-health-check-wf-swarm}[Health Check - {WildFlySwarm} Booster]

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -20,6 +20,6 @@ ifndef::wf-swarm[]
 * link:{link-mission-health-check-wf-swarm}[Health Check - {WildFlySwarm} Booster]
 endif::wf-swarm[]
 
-ifndef::node-js[]
+ifndef::built-for-nodejs[]
   * link:{link-mission-health-check-nodejs}[Health Check - {Node} Booster]
-endif::node-js[]
+endif::built-for-nodejs[]

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -16,9 +16,9 @@ ifndef::built-for-vertx[]
 * link:{link-mission-health-check-vertx}[Health Check - {VertX} Booster]
 endif::built-for-vertx[]
 
-ifndef::wf-swarm[]
+ifndef::built-for-thorntail[]
 * link:{link-mission-health-check-wf-swarm}[Health Check - {WildFlySwarm} Booster]
-endif::wf-swarm[]
+endif::built-for-thorntail[]
 
 ifndef::built-for-nodejs[]
   * link:{link-mission-health-check-nodejs}[Health Check - {Node} Booster]

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -8,9 +8,9 @@ More background and related information on health checking can be found here:
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Kubernetes Liveness and Readiness Probes]
 * link:https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe[Kubernetes Probes]
 
-ifndef::spring-boot[]
+ifndef::built-for-spring-boot[]
 * link:{link-mission-health-check-spring-boot}[Health Check - {SpringBoot} Booster]
-endif::spring-boot[]
+endif::built-for-spring-boot[]
 
 ifndef::vert-x[]
 * link:{link-mission-health-check-vertx}[Health Check - {VertX} Booster]

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -17,16 +17,16 @@ ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 
 ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 
-ifdef::vert-x[]
+ifdef::built-for-vertx[]
 * link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]
 * link:http://vertx.io/blog/using-the-asynchronous-sql-client/[Using the {VertX} asynchronous SQL client]
-endif::vert-x[]
+endif::built-for-vertx[]
 
 ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 
 ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{mission-crud-spring-boot-guide-name}]]
 
-ifndef::vert-x[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]]
+ifndef::built-for-vertx[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]]
 
 ifndef::wf-swarm[* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]]
 

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -15,7 +15,7 @@ ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311
 
 ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 
-ifdef::spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
+ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 
 ifdef::vert-x[]
 * link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]
@@ -24,7 +24,7 @@ endif::vert-x[]
 
 ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 
-ifndef::spring-boot[* link:{link-mission-crud-spring-boot}[{mission-crud-spring-boot-guide-name}]]
+ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{mission-crud-spring-boot-guide-name}]]
 
 ifndef::vert-x[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]]
 

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -11,9 +11,9 @@ the Design of Network-based Software Architectures - Representational State Tran
 * link:http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven[REST APIs must be Hypertext driven]
 * link:https://martinfowler.com/articles/richardsonMaturityModel.html[Richardson Maturity Model]
 
-ifndef::node-js[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
+ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
 
-ifdef::node-js[* link:https://expressjs.com/[Express Web Framework]]
+ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 
 ifdef::spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 
@@ -30,5 +30,5 @@ ifndef::vert-x[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]
 
 ifndef::wf-swarm[* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]]
 
-ifndef::node-js[* link:{link-mission-crud-nodejs}[{mission-crud-nodejs-guide-name}]]
+ifndef::built-for-nodejs[* link:{link-mission-crud-nodejs}[{mission-crud-nodejs-guide-name}]]
 

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -22,13 +22,13 @@ ifdef::built-for-vertx[]
 * link:http://vertx.io/blog/using-the-asynchronous-sql-client/[Using the {VertX} asynchronous SQL client]
 endif::built-for-vertx[]
 
-ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
+ifdef::built-for-thorntail[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 
 ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{mission-crud-spring-boot-guide-name}]]
 
 ifndef::built-for-vertx[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]]
 
-ifndef::wf-swarm[* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]]
+ifndef::built-for-thorntail[* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]]
 
 ifndef::built-for-nodejs[* link:{link-mission-crud-nodejs}[{mission-crud-nodejs-guide-name}]]
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -10,10 +10,10 @@ the Design of Network-based Software Architectures - Representational State Tran
 ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
 ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
-ifdef::vert-x[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
+ifdef::built-for-vertx[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
 ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
-ifndef::vert-x[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
+ifndef::built-for-vertx[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
 ifndef::wf-swarm[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
 ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -7,13 +7,13 @@ More background and related information on REST can be found here:
 the Design of Network-based Software Architectures - Representational State Transfer (REST)]
 * link:https://martinfowler.com/articles/richardsonMaturityModel.html[Richardson Maturity Model]
 
-ifndef::node-js[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
-ifdef::node-js[* link:https://expressjs.com/[Express Web Framework]]
+ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
+ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 ifdef::spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 ifdef::vert-x[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
 ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 ifndef::spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
 ifndef::vert-x[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
 ifndef::wf-swarm[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
-ifndef::node-js[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]
+ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -11,9 +11,9 @@ ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311
 ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
 ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 ifdef::built-for-vertx[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
-ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
+ifdef::built-for-thorntail[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
 ifndef::built-for-vertx[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
-ifndef::wf-swarm[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
+ifndef::built-for-thorntail[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
 ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -9,10 +9,10 @@ the Design of Network-based Software Architectures - Representational State Tran
 
 ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
 ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
-ifdef::spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
+ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
 ifdef::vert-x[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
 ifdef::wf-swarm[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
-ifndef::spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
+ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
 ifndef::vert-x[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
 ifndef::wf-swarm[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
 ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -16,5 +16,5 @@ ifndef::vert-x[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-
 
 ifndef::wf-swarm[* link:{link-mission-secured-wf-swarm}[{mission-secured-wf-swarm-guide-name}]]
 
-ifndef::node-js[* link:{link-mission-secured-nodejs}[{mission-secured-nodejs-guide-name}]]
+ifndef::built-for-nodejs[* link:{link-mission-secured-nodejs}[{mission-secured-nodejs-guide-name}]]
 

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -10,7 +10,7 @@ Follow the links below for additional information on the principles behind the O
 
 * link:http://www.keycloak.org/archive/documentation-3.2.html[Keycloak 3.2 Documentation]
 
-ifndef::spring-boot[* link:{link-mission-secured-spring-boot}[{mission-secured-spring-boot-guide-name}]]
+ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{mission-secured-spring-boot-guide-name}]]
 
 ifndef::vert-x[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-name}]]
 

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -14,7 +14,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{mission
 
 ifndef::built-for-vertx[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-name}]]
 
-ifndef::wf-swarm[* link:{link-mission-secured-wf-swarm}[{mission-secured-wf-swarm-guide-name}]]
+ifndef::built-for-thorntail[* link:{link-mission-secured-wf-swarm}[{mission-secured-wf-swarm-guide-name}]]
 
 ifndef::built-for-nodejs[* link:{link-mission-secured-nodejs}[{mission-secured-nodejs-guide-name}]]
 

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -12,7 +12,7 @@ Follow the links below for additional information on the principles behind the O
 
 ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{mission-secured-spring-boot-guide-name}]]
 
-ifndef::vert-x[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-name}]]
+ifndef::built-for-vertx[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-name}]]
 
 ifndef::wf-swarm[* link:{link-mission-secured-wf-swarm}[{mission-secured-wf-swarm-guide-name}]]
 

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -2,7 +2,7 @@ include::topics/templates/document-attributes.adoc[]
 
 //override for a cleaner TOC
 :toclevels: 2
-:vert-x:
+:built-for-vertx:
 
 = {vertx-runtime-guide-name}
 :runtime: {VertX}

--- a/docs/wf-swarm-runtime/master.adoc
+++ b/docs/wf-swarm-runtime/master.adoc
@@ -3,7 +3,7 @@ include::topics/templates/document-attributes.adoc[]
 // Used for specifying this is product docs in the modules sourced from the
 // WildFly Swarm repository (anything stored in docs/wildfly-swarm).
 :product:
-:wf-swarm:
+:built-for-thorntail:
 
 //override for a cleaner TOC
 :toclevels: 2


### PR DESCRIPTION
The following variables (attributes) were renamed:

* `node-js` -> `built-for-nodejs`
* `spring-boot` -> `built-for-spring-boot`
* `vert-x` -> `built-for-vertx`
* `wf-swarm` -> `built-for-thorntail`

I have diffed the resulting HTML files and except for the time stamp, they are identical.

Resolves [RHOARDOC-1403](https://issues.jboss.org/browse/RHOARDOC-1403).