### PR TITLE
RHOARDOC-1469: Prepare attributes file for portal publishing

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -214,3 +214,6 @@
 
 // Link S2I process (primarily for guides mission interaction sections)
 :link-s2i-process: https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#source-build
+
+include::document-attributes-portal.adoc[]
+


### PR DESCRIPTION
The `document-attributes-portal.adoc` file is intentionally left empty so that it can be filled in the downstream repository without conflicts, and to avoid a build warning in case it didn't exist.

The include directive is at the end of the file so that any values defined in the `document-attributes.adoc` file can be overwritten in the `document-attributes-portal.adoc` file.

Resolves RHOARDOC-1469