### PR TITLE
RHOARDOC-1472: Separated Launcher and Portal attribute definitions into separate files

### DIFF
--- a/docs/topics/con_repository-filesystem-layout.adoc
+++ b/docs/topics/con_repository-filesystem-layout.adoc
@@ -15,21 +15,24 @@ NOTE: The triple-dot indicates there are more files or directories in the partic
 │   │   ├── styles/ <4>
 │   │   ├── templates/ <5>
 │   │   │   ├── document-attributes.adoc <6>
+│   │   │   ├── document-attributes-launcher.adoc <7>
+│   │   │   ├── document-attributes-portal.adoc <8>
+│   │   │   ├── environment.adoc <9>
 │   │   │   ├── ...
-│   │   │   ├── thorntail <7>
-│   │   ├── circuit-breaker-mission-design-tradeoffs.adoc
-│   │   ├── ...
-│   ├── $GUIDE_NAME/ <8>
-│   │   ├── master.adoc <9>
-│   │   ├── build_guide.sh <10>
-│   │   └── topics/ -> ../topics <11>
-│   ├── ...
-├── scripts/ <12>
-│   ├── build_guides.sh <13>
-│   ├── validate_guides.sh <14>
-│   ├── ...
-├── cico_build_deploy <15>
-├── CHANGELOG.adoc <16>
+│   │   │   └── thorntail <10>
+│   │   ├── con_circuit-breaker-design-tradeoffs.adoc
+│   │   └── ...
+│   ├── $GUIDE_NAME/ <11>
+│   │   ├── master.adoc <12>
+│   │   ├── build_guide.sh <13>
+│   │   └── topics/ -> ../topics <14>
+│   └── ...
+├── scripts/ <15>
+│   ├── build_guides.sh <16>
+│   ├── validate_guides.sh <17>
+│   └── ...
+├── cico_build_deploy <18>
+├── CHANGELOG.adoc <19>
 └── README.adoc
 ----
 <1> The directory with the sources of all the _{docs-name}_ guides, the _launchpad.openshift.io_ page, and the contributor guide.
@@ -38,19 +41,23 @@ NOTE: The triple-dot indicates there are more files or directories in the partic
 <4> The directory with all the stylesheets used in the sources.
 <5> The directory with all the templates used in the sources.
 <6> The file where all the common document attributes are defined.
-<7> The directory with sources synchronized from the {WildFlySwarm} repository.
-<8> The directory with the sources of a guide. Each guide has exactly one directory like this.
-<9> The main AsciiDoc file of the guide. The files from the `topics` directory are included from this file.
-<10> The script for building the particular guide.
-<11> A symbolic link to the shared `$REPO_HOME/docs/topics/` directory.
-<12> The directory with scripts used for manipulating files in the directory, building, and more.
-<13> The script for building all guides at once. This script does not validate the guides.
-<14> The script for validating all guides at once.
-<15> The script to start local server and to publish to production. For more information, see xref:starting-preview-server_{context}[].
-<16> The file with changes made in each release.
+<7> The file where {launcher}{ndash}specific document attributes are defined.
+<8> The file where Red Hat Customer Portal{ndash}specific document attributes are defined.
+<9> The file that sets whether the documentation is built on the {launcher} or on the Red Hat Customer Portal.
+<10> The directory with sources synchronized from the {WildFlySwarm} repository.
+<11> The directory with the sources of a guide. Each guide has exactly one directory like this.
+<12> The main AsciiDoc file of the guide. The files from the `topics` directory are included from this file.
+<13> The script for building the particular guide.
+<14> A symbolic link to the shared `$REPO_HOME/docs/topics/` directory.
+<15> The directory with scripts used for manipulating files in the directory, building, and more.
+<16> The script for building all guides at once. This script does not validate the guides.
+<17> The script for validating all guides at once.
+<18> The script to start local server and to publish to production. For more information, see xref:starting-preview-server_{context}[].
+<19> The file with changes made in each release.
 
 WARNING: Do not edit files in the `$REPO_HOME/docs/topics/thorntail` directory, always submit a pull request to the link:{link-repo-wildfly-swarm}[{WildFlySwarm} repository] and synchronize the files afterwards.
 
 .Additional resources
 
 * xref:syncing-with-wildflyswarm-docs_{context}[]
+

--- a/docs/topics/templates/document-attributes-launcher.adoc
+++ b/docs/topics/templates/document-attributes-launcher.adoc
@@ -1,0 +1,20 @@
+
+:docinfodir: topics/styles
+:docinfo1:
+
+:ProductName: {OpenShiftAppDev}
+:ProductShortName: {ProductName}
+
+:imagesdir: images
+
+:stylesdir: topics/styles
+:stylesheet: foundation.css
+
+:link-openshift-local-guide: /docs/minishift-installation.html
+:link-launcher-openshift-local-install-guide: /docs/minishift-installation.html
+:link-getting-started-guide: /docs/getting-started.html
+:link-spring-boot-runtime-guide: /docs/spring-boot-runtime.html
+:link-vertx-runtime-guide: /docs/vertx-runtime.html
+:link-wf-swarm-runtime-guide: /docs/thorntail-runtime.html
+:link-nodejs-runtime-guide: /docs/nodejs-runtime.html
+

--- a/docs/topics/templates/document-attributes-portal.adoc
+++ b/docs/topics/templates/document-attributes-portal.adoc
@@ -1,0 +1,21 @@
+
+:imagesdir: topics/images
+
+:ProductName: Red Hat OpenShift Application Runtimes
+:ProductShortName: RHOAR
+:ProductRelease: 1
+:ProductVersion: 1
+:DocInfoProductNumber: 1
+:DocInfoProductName: red-hat-openshift-application-runtimes
+
+:portal-base-url: https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/{DocInfoProductNumber}/html-single
+:link-launcher-yaml: https://launcher.fabric8.io/latest-launcher-template
+
+:link-launcher-openshift-local-install-guide: {portal-base-url}/install_and_configure_the_developers.redhat.comlaunch_application_on_a_single-node_openshift_cluster/
+:link-openshift-local-guide: {link-launcher-openshift-local-install-guide}
+:link-getting-started-guide: {portal-base-url}/getting_started_guide/
+:link-spring-boot-runtime-guide: {portal-base-url}/spring_boot_tomcat_runtime_guide/
+:link-vertx-runtime-guide: {portal-base-url}/eclipse_vert.x_runtime_guide/
+:link-wf-swarm-runtime-guide: {portal-base-url}/wildfly_swarm_runtime_guide/
+:link-nodejs-runtime-guide: {portal-base-url}/node.js_runtime_guide/
+

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -1,29 +1,14 @@
+include::environment.adoc[]
+
 :toc: left
 :toclevels: 3
 :numbered:
-:docinfodir: topics/styles
-:docinfo1:
 :icons: font
 :source-highlighter: highlightjs
-
-:imagesdir: images
-
-:ndash: &#x2013;
-
-//uncomment to add styles
-:stylesdir: topics/styles
-//:stylesheet: style.css
-//:stylesheet: asciidoc-default.css
-:stylesheet: foundation.css
-
-//filter community-only content
-:launcher-docs-only:
 
 :launcher: Fabric8 Launcher
 :launcher-oso: developers.redhat.com/launch
 :OpenShiftAppDev: Application Development on OpenShift
-:ProductName: {OpenShiftAppDev}
-:ProductShortName: {ProductName}
 
 :OpenShiftOnline: OpenShift Online
 :OpenShiftLocal: Single-node OpenShift Cluster
@@ -38,6 +23,20 @@
 :RHSSO: Red Hat SSO
 // Needs to be set to either "WildFly" or "JBoss EAP"
 :WildFly: JBoss EAP
+
+// Launcher-specific attribute definitions
+ifdef::launcher-docs-only[]
+include::document-attributes-launcher.adoc[]
+endif::[]
+
+// Portal-specific docs attribute definitions
+ifdef::portal-docs-only[]
+include::document-attributes-portal.adoc[]
+endif::[]
+
+
+:ndash: &#x2013;
+
 
 :app-name: MY_APP_NAME
 :project-name: MY_PROJECT_NAME
@@ -79,8 +78,6 @@
 :mission-cache-vertx-guide-name: {name-mission-cache} Mission - {VertX} Booster
 :mission-cache-wf-swarm-guide-name: {name-mission-cache} Mission - {WildFlySwarm} Booster
 :mission-cache-nodejs-guide-name: {name-mission-cache} Mission - {Node} Booster
-
-
 
 :minishift-installation-guide-name: Install and Configure the {launcher} Tool
 :getting-started-guide-name: Getting Started with {ProductName}
@@ -128,15 +125,7 @@
 :link-configmap-nodejs-booster: https://github.com/nodeshift-starters/nodejs-configmap
 :link-configmap-wf-swarm-booster: https://github.com/wildfly-swarm-openshiftio-boosters/configmap
 
-:link-openshift-local-guide: /docs/minishift-installation.html
-:link-launcher-openshift-local-install-guide: /docs/minishift-installation.html
-:link-getting-started-guide: /docs/getting-started.html
-:link-spring-boot-runtime-guide: /docs/spring-boot-runtime.html
-:link-vertx-runtime-guide: /docs/vertx-runtime.html
-:link-wf-swarm-runtime-guide: /docs/thorntail-runtime.html
-:link-nodejs-runtime-guide: /docs/nodejs-runtime.html
-
-
+// SPRING BOOT MISSIONS
 :link-mission-http-api-spring-boot: {link-spring-boot-runtime-guide}#mission-rest-http-spring-boot
 :link-mission-configmap-spring-boot: {link-spring-boot-runtime-guide}#mission-configmap-spring-boot
 :link-mission-crud-spring-boot: {link-spring-boot-runtime-guide}#mission-crud-spring-boot
@@ -145,6 +134,7 @@
 :link-mission-circuit-breaker-spring-boot: {link-spring-boot-runtime-guide}#mission-circuit-breaker-spring-boot
 :link-mission-cache-spring-boot: {link-spring-boot-runtime-guide}#mission-cache-spring-boot
 
+// VERT.X MISSIONS
 :link-mission-http-api-vertx: {link-vertx-runtime-guide}#mission-rest-http-vertx
 :link-mission-configmap-vertx: {link-vertx-runtime-guide}#mission-configmap-vertx
 :link-mission-crud-vertx: {link-vertx-runtime-guide}#mission-crud-vertx
@@ -153,7 +143,7 @@
 :link-mission-circuit-breaker-vertx: {link-vertx-runtime-guide}#mission-circuit-breaker-vertx
 :link-mission-cache-vertx: {link-vertx-runtime-guide}#mission-cache-vertx
 
-
+// THORNTAIL MISSIONS
 :link-mission-http-api-wf-swarm: {link-wf-swarm-runtime-guide}#mission-rest-http-wf-swarm
 :link-mission-configmap-wf-swarm: {link-wf-swarm-runtime-guide}#mission-configmap-wf-swarm
 :link-mission-crud-wf-swarm: {link-wf-swarm-runtime-guide}#mission-crud-wf-swarm
@@ -162,6 +152,7 @@
 :link-mission-circuit-breaker-wf-swarm: {link-wf-swarm-runtime-guide}#mission-circuit-breaker-wf-swarm
 :link-mission-cache-wf-swarm: {link-wf-swarm-runtime-guide}#mission-cache-wf-swarm
 
+// NODE.JS MISSIONS
 :link-mission-http-api-nodejs: {link-nodejs-runtime-guide}#mission-rest-http-nodejs
 :link-mission-configmap-nodejs: {link-nodejs-runtime-guide}#mission-configmap-nodejs
 :link-mission-health-check-nodejs: {link-nodejs-runtime-guide}#mission-health-check-nodejs
@@ -214,6 +205,4 @@
 
 // Link S2I process (primarily for guides mission interaction sections)
 :link-s2i-process: https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#source-build
-
-include::document-attributes-portal.adoc[]
 

--- a/docs/topics/templates/environment.adoc
+++ b/docs/topics/templates/environment.adoc
@@ -1,0 +1,2 @@
+// Enter nothing except :launcher-docs-only: or :portal-docs-only:
+:launcher-docs-only:


### PR DESCRIPTION
The attribute definitions are now in two separate files with no redefinitions taking place. This means that if an attribute is to be different in the Launcher and on the Portal, it should be defined in the `document-attributes-launcher.adoc` and `document-attributes-portal.adoc` files as opposed to the main `document-attributes.adoc` file. In that file, only truly common attributes go.

Which of the specific files shall be included is determined by the content of the `environment.adoc` file that only contains `:launcher-docs-only:` in this repository, and `:portal-docs-only:` downstream.

The specific files are included in the middle of the `document-attributes.adoc` file to make it possible to both derive specific attributes from common ones or vice versa (this is why #1208 didn't work).

I have updated the Contribution Guide section about the repository layout accordingly.

This is a rework of #1208, resolves RHOARDOC-1472.

