### PR TITLE
RHOARDOC-1382: Replaced JBDS mentions with an attribute

### DIFF
--- a/docs/topics/assembly_using-red-hat-jboss-developer-studio-with-a-booster-project.adoc
+++ b/docs/topics/assembly_using-red-hat-jboss-developer-studio-with-a-booster-project.adoc
@@ -1,14 +1,14 @@
 
 [id='using-red-hat-jboss-developer-studio-with-a-booster-project_{context}']
-= Using Red Hat JBoss Developer Studio with a booster project
+= Using {DevStudio} with a booster project
 
-Red Hat JBoss Developer Studio is an integrated development environment, or IDE, that provides tooling for writing software.
+{DevStudio} is an integrated development environment, or IDE, that provides tooling for writing software.
 You can use it to make changes to your booster's code.
 
 .Prerequisites
 
 * Have a booster deployed to xref:deploying-a-booster-to-openshiftonline_{context}[{OpenShiftOnline}] or xref:creating-and-deploying-a-booster-using-your-openshiftlocal_{context}[{OpenShiftLocal}] using the _Deploy in OpenShift Online_ option.
-* Have Red Hat JBoss Developer Studio link:https://developers.redhat.com/products/devstudio/download/[downloaded from the Red Hat Developer Portal] and installed.
+* Have {DevStudio} link:https://developers.redhat.com/products/devstudio/download/[downloaded from the Red Hat Developer Portal] and installed.
 
 include::proc_importing-your-booster-code-to-red-hat-jboss-developer-studio.adoc[leveloffset=+1]
 

--- a/docs/topics/proc_attaching-a-remote-debugger-to-the-application.adoc
+++ b/docs/topics/proc_attaching-a-remote-debugger-to-the-application.adoc
@@ -3,17 +3,17 @@
 = Attaching a remote debugger to the application
 
 When your application is configured for debugging, attach a remote debugger of your choice to it.
-In this guide, link:https://www.redhat.com/en/technologies/jboss-middleware/developer-studio[Red Hat JBoss Developer Studio] is covered, but the procedure is similar when using other programs.
+In this guide, link:https://www.redhat.com/en/technologies/jboss-middleware/developer-studio[{DevStudio}] is covered, but the procedure is similar when using other programs.
 
 .Prerequisites
 
 * The application running either locally or on OpenShift, and configured for debugging.
 * The port number that your application is listening on for debugging.
-* Red Hat JBoss Developer Studio installed on your machine. You can download it from the link:https://developers.redhat.com/products/devstudio/download/[Red Hat JBoss Developer Studio download page].
+* {DevStudio} installed on your machine. You can download it from the link:https://developers.redhat.com/products/devstudio/download/[{DevStudio} download page].
 
 .Procedure
 
-. Start Red Hat JBoss Developer Studio.
+. Start {DevStudio}.
 . Create a new debug configuration for your application:
 .. Click *Run->Debug Configurations*.
 .. In the list of configurations, double-click *Remote Java application.*

--- a/docs/topics/proc_committing-and-pushing-changes-to-the-github-repository-of-your-booster.adoc
+++ b/docs/topics/proc_committing-and-pushing-changes-to-the-github-repository-of-your-booster.adoc
@@ -2,7 +2,7 @@
 [id='committing-and-pushing-changes-to-the-github-repository-of-your-booster_{context}']
 = Committing and pushing changes to the GitHub repository of your booster
 
-Red Hat JBoss Developer Studio provides tooling for committing and pushing code through Git directly in the IDE. Alternatively, you can use Red Hat JBoss Developer Studio to make changes and push those changes with the Git CLI.
+{DevStudio} provides tooling for committing and pushing code through Git directly in the IDE. Alternatively, you can use {DevStudio} to make changes and push those changes with the Git CLI.
 
 .Prerequisites
 

--- a/docs/topics/proc_importing-your-booster-code-to-red-hat-jboss-developer-studio.adoc
+++ b/docs/topics/proc_importing-your-booster-code-to-red-hat-jboss-developer-studio.adoc
@@ -1,13 +1,13 @@
 
 [id='importing-your-booster-code-to-red-hat-jboss-developer-studio_{context}']
-= Importing your booster code to Red Hat JBoss Developer Studio
+= Importing your booster code to {DevStudio}
 
-Importing your booster's code creates a project in Red Hat JBoss Developer Studio and enables you to start making changes.
+Importing your booster's code creates a project in {DevStudio} and enables you to start making changes.
 
 .Prerequisites
 
 * Your booster created and downloaded from link:{link-launcher-oso}[{launcher-oso}].
-* Red Hat JBoss Developer Studio running.
+* {DevStudio} running.
 
 .Procedure
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -23,6 +23,7 @@ include::environment.adoc[]
 :RHSSO: Red Hat SSO
 // Needs to be set to either "WildFly" or "JBoss EAP"
 :WildFly: JBoss EAP
+:DevStudio: Red Hat Developer Studio
 
 // Launcher-specific attribute definitions
 ifdef::launcher-docs-only[]


### PR DESCRIPTION
Note: I have left one mention of _JBoss Developer Studio_ in a link to a KB article because that is literally the title of the article.

I did not update the anchor IDs in order not to break links, and because this change seems rather minor in that context. If you believe I should update them too, feel free to request that.