### PR TITLE
RHOARDOC-1470: Refactored attributes

### DIFF
--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -20,7 +20,7 @@ _TBD_
 
 == Documentation
 
-This chapter contains information about contributing and releasing the {docs-name} documentation. You can also contribute to the documentation by filing an issue in our link:https://issues.jboss.org/projects/RHOARDOC/[Jira] project with corrections or feedback.
+This chapter contains information about contributing and releasing the {name-docs} documentation. You can also contribute to the documentation by filing an issue in our link:https://issues.jboss.org/projects/RHOARDOC/[Jira] project with corrections or feedback.
 
 include::topics/contributing-before-you-start.adoc[leveloffset=+2]
 

--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -6,13 +6,13 @@ include::topics/templates/document-attributes.adoc[]
 
 :context: contributing
 
-== {launcher} development
+== {name-launcher} development
 
-This chapter contains information about developing your own runtimes or boosters, contributing changes to existing ones, and improving {launcher}.
+This chapter contains information about developing your own runtimes or boosters, contributing changes to existing ones, and improving {name-launcher}.
 
 include::topics/assembly_updating-booster-catalog-for-local-openshiftlocal-testing.adoc[leveloffset=+2]
 
-You can preview the latest state of {launcher} by navigating to the link:{launcher-stage}[stage build] of {launcher}.
+You can preview the latest state of {name-launcher} by navigating to the link:{launcher-stage}[stage build] of {name-launcher}.
 
 == Filing a code issue
 

--- a/docs/contrib-guide/master.adoc
+++ b/docs/contrib-guide/master.adoc
@@ -2,7 +2,7 @@ include::topics/templates/document-attributes.adoc[]
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:
 
-= {contrib-guide-name}
+= {name-guide-contrib}
 
 :context: contributing
 

--- a/docs/getting-started/master.adoc
+++ b/docs/getting-started/master.adoc
@@ -7,7 +7,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: getting-started
 
 :sectnums!:
-= {getting-started-guide-name}
+= {name-guide-getting-started}
 
 This guide covers basic information to get started using {ProductName}.
 

--- a/docs/getting-started/master.adoc
+++ b/docs/getting-started/master.adoc
@@ -19,7 +19,7 @@ This enables you to break your business problems into smaller microservices whil
 These cloud-native development approaches take advantage of the capabilities provided by OpenShift and enable you to use patterns such as Circuit Breaker, Health Check, and Service Discovery.
 
 This guide takes you through cloud-native development on OpenShift.
-It shows you how to create and deploy example cloud-native applications called boosters to OpenShift using {launcher-oso} or the {launcher} tool.
+It shows you how to create and deploy example cloud-native applications called boosters to OpenShift using {name-launcher-oso} or the {name-launcher} tool.
 These example applications can serve as the foundation for your actual cloud-native microservices since they can be updated and redeployed using the same deployment process detailed in this guide.
 
 include::topics/con_introduction-to-productname.adoc[leveloffset=+1]

--- a/docs/landing-page/master.adoc
+++ b/docs/landing-page/master.adoc
@@ -2,7 +2,7 @@ include::topics/templates/document-attributes.adoc[]
 
 :landing-page:
 :toc!:
-:title: {OpenShiftAppDev}
+:title: {ProductName}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:
 

--- a/docs/minishift-installation/master.adoc
+++ b/docs/minishift-installation/master.adoc
@@ -9,7 +9,7 @@ include::topics/templates/document-attributes.adoc[]
 :context: minishift
 
 [.lead]
-This guide walks you through the process of installing the {launcher} tool to run on a local cloud as provisioned by a {OpenShiftLocal}. This includes link:https://www.openshift.org/minishift/[{Minishift}], an all-in-one VM that includes a community version of OpenShift Origin, or link:https://developers.redhat.com/products/cdk/overview/[{CDK}], a VM that includes OpenShift Container Platform.
+This guide walks you through the process of installing the {name-launcher} tool to run on a local cloud as provisioned by a {OpenShiftLocal}. This includes link:https://www.openshift.org/minishift/[{Minishift}], an all-in-one VM that includes a community version of OpenShift Origin, or link:https://developers.redhat.com/products/cdk/overview/[{CDK}], a VM that includes OpenShift Container Platform.
 
 include::topics/con_how-the-launcher-tool-works.adoc[leveloffset=+1]
 
@@ -20,8 +20,8 @@ include::topics/proc_starting-and-configuring-the-openshiftlocal-for-the-launche
 include::topics/proc_creating-a-github-personal-access-token.adoc[leveloffset=+1]
 
 [id='installing-launcher-tool_{context}']
-== Installing {launcher} Tool
-Install a local customized instance of the {launcher} tool, which allows you to test the functionality or make modifications to the service using a web interface.
+== Installing {name-launcher} Tool
+Install a local customized instance of the {name-launcher} tool, which allows you to test the functionality or make modifications to the service using a web interface.
 
 include::topics/proc_installing-launcher-tool-addon.adoc[leveloffset=+2]
 

--- a/docs/minishift-installation/master.adoc
+++ b/docs/minishift-installation/master.adoc
@@ -4,7 +4,7 @@ include::topics/templates/document-attributes.adoc[]
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:
 
-= {minishift-installation-guide-name}
+= {name-guide-minishift-installation}
 
 :context: minishift
 

--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -93,10 +93,9 @@ include::topics/proc_starting-your-application-locally-and-attaching-the-native-
 
 include::topics/proc_starting-your-application-locally-and-attaching-the-v8-inspector.adoc[leveloffset=+3]
 
-:nodejs:
-:env-var-name: NODE_ENV
-:env-var-val: development
-:port: 5858
+:parameter-env-var-name: NODE_ENV
+:parameter-env-var-value: development
+:parameter-port: 5858
 //include::topics/proc_debug-start-v8-debug-nodejs-openshift.adoc[leveloffset=+3]
 include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
 

--- a/docs/nodejs-runtime/master.adoc
+++ b/docs/nodejs-runtime/master.adoc
@@ -3,7 +3,7 @@ include::topics/templates/document-attributes.adoc[]
 //override for a cleaner TOC
 :toclevels: 2
 
-= {nodejs-runtime-guide-name}
+= {name-guide-nodejs}
 :runtime: {Node}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -3,7 +3,7 @@ include::topics/templates/document-attributes.adoc[]
 :toclevels: 2
 :built-for-spring-boot:
 
-= {spring-boot-runtime-guide-name}
+= {name-guide-spring-boot}
 :runtime: {SpringBoot}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:

--- a/docs/spring-boot-runtime/master.adoc
+++ b/docs/spring-boot-runtime/master.adoc
@@ -108,10 +108,9 @@ include::topics/proc_starting-your-springboot-application-locally-in-debugging-m
 
 include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
 
-:env-var-name: JAVA_DEBUG
-:env-var-val: true
-:port: 5005
-:nodejs!:
+:parameter-env-var-name: JAVA_DEBUG
+:parameter-env-var-value: true
+:parameter-port: 5005
 include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
 
 include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]

--- a/docs/thorntail-runtime/master.adoc
+++ b/docs/thorntail-runtime/master.adoc
@@ -8,7 +8,7 @@ include::topics/templates/document-attributes.adoc[]
 //override for a cleaner TOC
 :toclevels: 2
 
-= {wf-swarm-runtime-guide-name}
+= {name-guide-thorntail}
 :runtime: {WildFlySwarm}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:

--- a/docs/thorntail-runtime/master.adoc
+++ b/docs/thorntail-runtime/master.adoc
@@ -142,10 +142,9 @@ include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[le
 include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
 :parameter-uberjar-documented!:
 
-:env-var-name: JAVA_DEBUG
-:env-var-val: true
-:port: 5005
-:nodejs!:
+:parameter-env-var-name: JAVA_DEBUG
+:parameter-env-var-value: true
+:parameter-port: 5005
 include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
 
 include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]

--- a/docs/thorntail-runtime/master.adoc
+++ b/docs/thorntail-runtime/master.adoc
@@ -92,7 +92,7 @@ include::topics/assembly_cache-mission-booster.adoc[leveloffset=+2]
 
 This sections contains information about creating your application and configuring the {WildFlySwarm} runtime for it.
 
-:version: {WildFlySwarmProductVersion}
+:version: {version-thorntail-product}
 include::topics/assembly_creating-a-basic-wildfly-swarm-application.adoc[leveloffset=+2]
 
 include::topics/proc_deploying-an-existing-wildflyswarm-application-to-openshift.adoc[leveloffset=+2]

--- a/docs/topics/assembly_creating-a-basic-springboot-application.adoc
+++ b/docs/topics/assembly_creating-a-basic-springboot-application.adoc
@@ -9,7 +9,7 @@ In addition to xref:mission-rest-http-spring-boot[using a booster], you can crea
 :parameter-runtime: spring-boot
 :parameter-maven-command: $ mvn spring-boot:run
 :parameter-response: {"content":"Greetings!"}
-:parameter-url: http://{app-name}-{project-name}.{os-route-hostname}
+:parameter-url: http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}
 include::proc_creating-an-application.adoc[leveloffset=+1]
 
 include::proc_deploying-an-application-to-openshift.adoc[leveloffset=+1]

--- a/docs/topics/assembly_creating-a-basic-vertx-application.adoc
+++ b/docs/topics/assembly_creating-a-basic-vertx-application.adoc
@@ -9,7 +9,7 @@ In addition to xref:mission-rest-http-vertx[using a booster], you can create new
 :parameter-runtime: vertx
 :parameter-maven-command: $ mvn vertx:run
 :parameter-response: Greetings!
-:parameter-url: http://{app-name}-{project-name}.{os-route-hostname}
+:parameter-url: http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}
 include::proc_creating-an-application.adoc[leveloffset=+1]
 
 include::proc_deploying-an-application-to-openshift.adoc[leveloffset=+1]

--- a/docs/topics/assembly_creating-a-basic-wildfly-swarm-application.adoc
+++ b/docs/topics/assembly_creating-a-basic-wildfly-swarm-application.adoc
@@ -10,7 +10,7 @@ include::thorntail/docs/howto/writing-an-application-from-scratch/index.adoc[lev
 
 :parameter-maven-command: $ mvn thorntail:run
 :parameter-response: Hello from Thorntail!
-:parameter-url: http://{app-name}-{project-name}.{os-route-hostname}/rest/hello
+:parameter-url: http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/rest/hello
 include::proc_deploying-an-application-to-openshift.adoc[leveloffset=+1]
 :parameter-maven-command!:
 :parameter-response:

--- a/docs/topics/assembly_deploying-the-booster-to-openshiftlocal.adoc
+++ b/docs/topics/assembly_deploying-the-booster-to-openshiftlocal.adoc
@@ -14,21 +14,21 @@
 
 Use one of the following options to execute the {parameter-mission-name} booster locally on {OpenShiftLocal}:
 
-* xref:deploying-the-booster-using-the-launcher-tool_{context}[Using {launcher}]
+* xref:deploying-the-booster-using-the-launcher-tool_{context}[Using {name-launcher}]
 * xref:deploying-the-{parameter-mission}-booster-using-the-oc-cli-client_{context}[Using the `oc` CLI client]
 
-Although each method uses the same `oc` commands to deploy your application, using {launcher} provides an automated booster deployment workflow that executes the `oc` commands for you.
+Although each method uses the same `oc` commands to deploy your application, using {name-launcher} provides an automated booster deployment workflow that executes the `oc` commands for you.
 
 include::proc_getting-the-launcher-tool-url-and-credentials.adoc[leveloffset=+1]
 
 :parameter-openshiftlocal:
-:parameter-deployment: {launcher}
+:parameter-deployment: {name-launcher}
 include::proc_deploying-the-booster-using-the-launcher-tool.adoc[leveloffset=+1]
 
 :parameter-deployment: {OpenShiftLocal}
 include::proc_authenticating-the-oc-cli-client.adoc[leveloffset=+1]
 
-:parameter-deployment: {launcher} tool on a {OpenShiftLocal}
+:parameter-deployment: {name-launcher} tool on a {OpenShiftLocal}
 include::proc_deploying-the-{parameter-mission}-booster-using-the-oc-cli-client.adoc[leveloffset=+1]
 :parameter-deployment!:
 :parameter-openshiftlocal!:

--- a/docs/topics/assembly_deploying-the-booster-to-openshiftonline.adoc
+++ b/docs/topics/assembly_deploying-the-booster-to-openshiftonline.adoc
@@ -14,18 +14,18 @@
 
 Use one of the following options to execute the {parameter-mission-name} booster on {OpenShiftOnline}.
 
-* xref:deploying-the-booster-using-launcher-oso_{context}[Use {launcher-oso}]
+* xref:deploying-the-booster-using-launcher-oso_{context}[Use {name-launcher-oso}]
 * xref:deploying-the-{parameter-mission}-booster-using-the-oc-cli-client_{context}[Use the `oc` CLI client]
 
-Although each method uses the same `oc` commands to deploy your application, using {launcher-oso} provides an automated booster deployment workflow that executes the `oc` commands for you.
+Although each method uses the same `oc` commands to deploy your application, using {name-launcher-oso} provides an automated booster deployment workflow that executes the `oc` commands for you.
 
 :parameter-deployment: link:https://manage.openshift.com[{OpenShiftOnline}]
-:parameter-launcher: link:{link-launcher-oso}[{launcher-oso}]
+:parameter-launcher: link:{link-launcher-oso}[{name-launcher-oso}]
 include::proc_deploying-the-booster-using-launcher-oso.adoc[leveloffset=+1]
 
 include::proc_authenticating-the-oc-cli-client.adoc[leveloffset=+1]
 
-:parameter-deployment: link:{link-launcher-oso}[{launcher-oso}]
+:parameter-deployment: link:{link-launcher-oso}[{name-launcher-oso}]
 include::proc_deploying-the-{parameter-mission}-booster-using-the-oc-cli-client.adoc[leveloffset=+1]
 :parameter-deployment!:
 

--- a/docs/topics/con_guide-structure.adoc
+++ b/docs/topics/con_guide-structure.adoc
@@ -10,7 +10,7 @@ include::topics/templates/document-attributes.adoc[] <1>
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end <2>
 :docs-topic: <3>
 
-= {contrib-guide-name} <4>
+= {name-guide-contrib} <4>
 
 
 == {launcher} Development

--- a/docs/topics/con_guide-structure.adoc
+++ b/docs/topics/con_guide-structure.adoc
@@ -13,13 +13,13 @@ include::topics/templates/document-attributes.adoc[] <1>
 = {name-guide-contrib} <4>
 
 
-== {launcher} Development
+== {name-launcher} Development
 
-This chapter contains information about developing your own runtimes or boosters, contributing changes to existing ones, and improving {launcher}.
+This chapter contains information about developing your own runtimes or boosters, contributing changes to existing ones, and improving {name-launcher}.
 
 include::topics/assembly_updating-booster-catalog-for-local-openshiftlocal-testing.adoc[leveloffset=+2] <5>
 
-You can preview the latest state of {launcher} by navigating to the link:{launcher-stage}[stage build] of {launcher}.
+You can preview the latest state of {name-launcher} by navigating to the link:{launcher-stage}[stage build] of {name-launcher}.
 
 == Filing a code issue
 ...

--- a/docs/topics/con_how-the-launcher-tool-works.adoc
+++ b/docs/topics/con_how-the-launcher-tool-works.adoc
@@ -1,11 +1,11 @@
 [id='how-the-launcher-tool-works_{context}']
-= How the {launcher} tool works
+= How the {name-launcher} tool works
 
-The {launcher} tool runs on OpenShift and lets you create functional example applications called missions. The {launcher} tool walks you through:
+The {name-launcher} tool runs on OpenShift and lets you create functional example applications called missions. The {name-launcher} tool walks you through:
 
 * choosing the mission you want to generate,
 * choosing the runtime you want to use, and
 * choosing how you want to build and execute the mission.
 
-The {launcher} tool uses your choices to generate a custom project, called a booster, and either launches it directly to the same OpenShift instance, or provides a downloadable ZIP version of the project.
+The {name-launcher} tool uses your choices to generate a custom project, called a booster, and either launches it directly to the same OpenShift instance, or provides a downloadable ZIP version of the project.
 

--- a/docs/topics/con_introduction-to-productname.adoc
+++ b/docs/topics/con_introduction-to-productname.adoc
@@ -30,7 +30,7 @@ You can find more details on using {launcher-oso} in the xref:deploying-a-booste
 .The {launcher} Tool
 The {launcher} is the upstream project from which link:{link-launcher-oso}[{launcher-oso}] is based.
 
-You can also install and execute the {launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-launcher-openshift-local-install-guide}#installing-launcher-tool_minishift[Installing the {launcher} Tool] chapter of the {minishift-installation-guide-name} guide.
+You can also install and execute the {launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-launcher-openshift-local-install-guide}#installing-launcher-tool_minishift[Installing the {launcher} Tool] chapter of the {name-guide-minishift-installation} guide.
 
 .Missions and Boosters
 A mission implements a link:http://microservices.io/patterns/microservices.html[Microservice pattern] such as:

--- a/docs/topics/con_introduction-to-productname.adoc
+++ b/docs/topics/con_introduction-to-productname.adoc
@@ -18,19 +18,19 @@ link:https://www.openshift.com[Red Hat OpenShift] is a container application pla
 
 
 [[launcher-details]]
-.{launcher-oso}
-link:{link-launcher-oso}[{launcher-oso}] is a project generator offered by Red Hat to accelerate your experience with cloud-native development on OpenShift. It provides a hassle-free way of creating example applications, called boosters, as well as an easy way to build and deploy those boosters to OpenShift. To use link:{link-launcher-oso}[{launcher-oso}]:
+.{name-launcher-oso}
+link:{link-launcher-oso}[{name-launcher-oso}] is a project generator offered by Red Hat to accelerate your experience with cloud-native development on OpenShift. It provides a hassle-free way of creating example applications, called boosters, as well as an easy way to build and deploy those boosters to OpenShift. To use link:{link-launcher-oso}[{name-launcher-oso}]:
 
-* Navigate to link:{link-launcher-oso}[{launcher-oso}].
+* Navigate to link:{link-launcher-oso}[{name-launcher-oso}].
 * Choose the details for your example application.
 * Deploy application to OpenShift automatically or manually.
 
-You can find more details on using {launcher-oso} in the xref:deploying-a-booster-to-openshiftonline_{context}[] section.
+You can find more details on using {name-launcher-oso} in the xref:deploying-a-booster-to-openshiftonline_{context}[] section.
 
-.The {launcher} Tool
-The {launcher} is the upstream project from which link:{link-launcher-oso}[{launcher-oso}] is based.
+.The {name-launcher} Tool
+The {name-launcher} is the upstream project from which link:{link-launcher-oso}[{name-launcher-oso}] is based.
 
-You can also install and execute the {launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Installing the {launcher} Tool] chapter of the {name-guide-minishift-installation} guide.
+You can also install and execute the {name-launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Installing the {name-launcher} Tool] chapter of the {name-guide-minishift-installation} guide.
 
 .Missions and Boosters
 A mission implements a link:http://microservices.io/patterns/microservices.html[Microservice pattern] such as:
@@ -53,7 +53,7 @@ Each mission is implemented in one or more runtimes. Both the specific implement
 [#build-and-deploy-process]
 .Process for Building and Deploying to OpenShift
 
-When using link:{link-launcher-oso}[{launcher-oso}], you can create and deploy a booster to OpenShift using the _Build and Deploy to OpenShift_ build process, which is based on the link:{link-guide-thorntail}#the-source-to-image-s2i-build-process[Source-to-Image (S2I) build process]. _Build and Deploy to OpenShift_ configures OpenShift to pull the code of your booster from your GitHub repository, build the code, and deploy it to OpenShift.
+When using link:{link-launcher-oso}[{name-launcher-oso}], you can create and deploy a booster to OpenShift using the _Build and Deploy to OpenShift_ build process, which is based on the link:{link-guide-thorntail}#the-source-to-image-s2i-build-process[Source-to-Image (S2I) build process]. _Build and Deploy to OpenShift_ configures OpenShift to pull the code of your booster from your GitHub repository, build the code, and deploy it to OpenShift.
 
 The benefit of this process is that it handles all the configuration, building, and deployment steps needed to get your booster running in OpenShift. It also allows you to quickly deploy code updates and see your changes in OpenShift.
 

--- a/docs/topics/con_introduction-to-productname.adoc
+++ b/docs/topics/con_introduction-to-productname.adoc
@@ -30,7 +30,7 @@ You can find more details on using {launcher-oso} in the xref:deploying-a-booste
 .The {launcher} Tool
 The {launcher} is the upstream project from which link:{link-launcher-oso}[{launcher-oso}] is based.
 
-You can also install and execute the {launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-launcher-openshift-local-install-guide}#installing-launcher-tool_minishift[Installing the {launcher} Tool] chapter of the {name-guide-minishift-installation} guide.
+You can also install and execute the {launcher} tool on your {OpenShiftLocal} to use the same capabilities within your {OpenShiftLocal}. For more information, see the link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Installing the {launcher} Tool] chapter of the {name-guide-minishift-installation} guide.
 
 .Missions and Boosters
 A mission implements a link:http://microservices.io/patterns/microservices.html[Microservice pattern] such as:
@@ -53,7 +53,7 @@ Each mission is implemented in one or more runtimes. Both the specific implement
 [#build-and-deploy-process]
 .Process for Building and Deploying to OpenShift
 
-When using link:{link-launcher-oso}[{launcher-oso}], you can create and deploy a booster to OpenShift using the _Build and Deploy to OpenShift_ build process, which is based on the link:{link-wf-swarm-runtime-guide}#the-source-to-image-s2i-build-process[Source-to-Image (S2I) build process]. _Build and Deploy to OpenShift_ configures OpenShift to pull the code of your booster from your GitHub repository, build the code, and deploy it to OpenShift.
+When using link:{link-launcher-oso}[{launcher-oso}], you can create and deploy a booster to OpenShift using the _Build and Deploy to OpenShift_ build process, which is based on the link:{link-guide-thorntail}#the-source-to-image-s2i-build-process[Source-to-Image (S2I) build process]. _Build and Deploy to OpenShift_ configures OpenShift to pull the code of your booster from your GitHub repository, build the code, and deploy it to OpenShift.
 
 The benefit of this process is that it handles all the configuration, building, and deployment steps needed to get your booster running in OpenShift. It also allows you to quickly deploy code updates and see your changes in OpenShift.
 

--- a/docs/topics/con_missions-and-cloud-native-development-on-openshift.adoc
+++ b/docs/topics/con_missions-and-cloud-native-development-on-openshift.adoc
@@ -32,4 +32,4 @@ For example, the {name-mission-http-api} mission is implemented for these runtim
 * link:{link-mission-http-api-nodejs}[{Node} booster]
 * link:{link-mission-http-api-spring-boot}[{SpringBoot} booster]
 * link:{link-mission-http-api-vertx}[{VertX} booster]
-* link:{link-mission-http-api-wf-swarm}[{WildFlySwarm} booster]
+* link:{link-mission-http-api-thorntail}[{WildFlySwarm} booster]

--- a/docs/topics/con_quality-control-requirements-for-documentation.adoc
+++ b/docs/topics/con_quality-control-requirements-for-documentation.adoc
@@ -8,5 +8,5 @@ To ensure good quality of the documentation, the following requirements must be 
 ** One member of the documentation team (different from the submitter).
 ** One member of either the engineering team or the QE team.
 
-* When a new version of the documentation is released to {docs-name}, a member of the QE team must review the diff between the live version and the new version.
+* When a new version of the documentation is released to {name-docs}, a member of the QE team must review the diff between the live version and the new version.
 

--- a/docs/topics/con_repository-filesystem-layout.adoc
+++ b/docs/topics/con_repository-filesystem-layout.adoc
@@ -2,7 +2,7 @@
 
 = Repository filesystem layout
 
-The following diagram describes the filesystem layout of the _{repo-docs-name}_ repository:
+The following diagram describes the filesystem layout of the _{name-repo-docs}_ repository:
 
 NOTE: The triple-dot indicates there are more files or directories in the particular directory.
 
@@ -35,7 +35,7 @@ NOTE: The triple-dot indicates there are more files or directories in the partic
 ├── CHANGELOG.adoc <19>
 └── README.adoc
 ----
-<1> The directory with the sources of all the _{docs-name}_ guides, the _launchpad.openshift.io_ page, and the contributor guide.
+<1> The directory with the sources of all the _{name-docs}_ guides, the _launchpad.openshift.io_ page, and the contributor guide.
 <2> The directory with the actual sources in AsciiDoc files. This directory is shared among all guides.
 <3> The directory with all the images used in the sources.
 <4> The directory with all the stylesheets used in the sources.

--- a/docs/topics/con_repository-filesystem-layout.adoc
+++ b/docs/topics/con_repository-filesystem-layout.adoc
@@ -41,9 +41,9 @@ NOTE: The triple-dot indicates there are more files or directories in the partic
 <4> The directory with all the stylesheets used in the sources.
 <5> The directory with all the templates used in the sources.
 <6> The file where all the common document attributes are defined.
-<7> The file where {launcher}{ndash}specific document attributes are defined.
+<7> The file where {name-launcher}{ndash}specific document attributes are defined.
 <8> The file where Red Hat Customer Portal{ndash}specific document attributes are defined.
-<9> The file that sets whether the documentation is built on the {launcher} or on the Red Hat Customer Portal.
+<9> The file that sets whether the documentation is built on the {name-launcher} or on the Red Hat Customer Portal.
 <10> The directory with sources synchronized from the {WildFlySwarm} repository.
 <11> The directory with the sources of a guide. Each guide has exactly one directory like this.
 <12> The main AsciiDoc file of the guide. The files from the `topics` directory are included from this file.

--- a/docs/topics/con_rhsso-realm-model.adoc
+++ b/docs/topics/con_rhsso-realm-model.adoc
@@ -27,7 +27,7 @@ An example representation of the role mappings is provided in this decoded JWT b
   "exp": 1510162193,
   "nbf": 0,
   "iat": 1510161593,
-  "iss": "https://secure-sso-sso.{osl-route-hostname}/auth/realms/master", <1>
+  "iss": "https://secure-sso-sso.{value-route-osl-hostname}/auth/realms/master", <1>
   "aud": "demoapp",
   "sub": "c0175ccb-0892-4b31-829f-dda873815fe8",
   "typ": "Bearer",

--- a/docs/topics/con_what-is-springboot.adoc
+++ b/docs/topics/con_what-is-springboot.adoc
@@ -2,7 +2,7 @@
 = What is {SpringBoot}
 
 {SpringBoot} lets you create stand-alone Spring-based applications.
-See link:{link-spring-boot-runtime-guide}#additional-springboot-resources_spring-boot[Additional Resources] for a list of documents about {SpringBoot}.
+See link:{link-guide-spring-boot}#additional-springboot-resources_spring-boot[Additional Resources] for a list of documents about {SpringBoot}.
 
 The {SpringBoot} runtime gives you the advantages and convenience of the OpenShift platform:
 

--- a/docs/topics/contributing-before-you-start.adoc
+++ b/docs/topics/contributing-before-you-start.adoc
@@ -45,7 +45,7 @@ WARNING: On RHEL, CentOS, or Fedora, use the `gpg2` binary everywhere instead of
 . link:https://help.github.com/articles/telling-git-about-your-gpg-key/[Configure GPG with git] on your machine.
 +
 NOTE: On RHEL, CentOS, or Fedora, ensure to also add `gpg2` as the signing program according to the linked instructions.
-. In the _{repo-docs-name}_ repository, set automatic signing with your GPG key:
+. In the _{name-repo-docs}_ repository, set automatic signing with your GPG key:
 +
 --
 [source,bash]
@@ -64,12 +64,12 @@ $ git config --global gpg.program gpg2
 
 == Setting up Git hooks _(recommended)_
 
-To make a contribution to the {repo-docs-name} repository, you need to set up the Git hooks directory. These hooks automatically make sure at commit time that your contribution does not break important parts of the repository.
+To make a contribution to the {name-repo-docs} repository, you need to set up the Git hooks directory. These hooks automatically make sure at commit time that your contribution does not break important parts of the repository.
 
 .Procedure
 
-.Setting up Git Hooks in {repo-docs-name} Repository
-. In a terminal application, navigate to the directory with the {repo-docs-name} repository.
+.Setting up Git Hooks in {name-repo-docs} Repository
+. In a terminal application, navigate to the directory with the {name-repo-docs} repository.
 . Set the Git hook directory to `$REPO_HOME/.githooks`:
 +
 [source,bash,options="nowrap"]

--- a/docs/topics/getting-started-launchpad-continuous-delivery-warning.adoc
+++ b/docs/topics/getting-started-launchpad-continuous-delivery-warning.adoc
@@ -1,4 +1,4 @@
 [IMPORTANT]
 --
-You must grant *{launcher}* access to your GitHub and OpenShift accounts. You only need to do this once for every account.
+You must grant *{name-launcher}* access to your GitHub and OpenShift accounts. You only need to do this once for every account.
 --

--- a/docs/topics/messaging-README.adoc
+++ b/docs/topics/messaging-README.adoc
@@ -47,9 +47,9 @@ $ ${OSORunCMD}
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route ${app-name} -o jsonpath={$.spec.host}
+$ oc get route ${value-name-app} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
+${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 . Navigate to the `frontend` service using your browser to access the messaging service UI.
@@ -70,8 +70,8 @@ You can see the processed message appear in the _Responses_ table along with the
 $ oc get pods
 NAME                              READY     STATUS      RESTARTS   AGE
 ...
-${app-name}-worker-1-aaaaa        1/1       Running     0          6m
-${app-name}-worker-1-bbbbb        1/1       Running     0          4m
+${value-name-app}-worker-1-aaaaa        1/1       Running     0          6m
+${value-name-app}-worker-1-bbbbb        1/1       Running     0          4m
 ...
 ----
 --

--- a/docs/topics/note-web-form-rest-api.adoc
+++ b/docs/topics/note-web-form-rest-api.adoc
@@ -1,1 +1,1 @@
-NOTE: From a browser, you can also use a form provided by the booster to perform these same interactions. The form is located at the root of the project `\http://{app-name}-{project-name}.{os-route-hostname}`.
+NOTE: From a browser, you can also use a form provided by the booster to perform these same interactions. The form is located at the root of the project `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}`.

--- a/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
+++ b/docs/topics/proc_accessing-debug-logs-on-openshift.adoc
@@ -72,7 +72,7 @@ ifdef::built-for-vertx[]
 [source,options="nowrap",subs="attributes+"]
 ----
 ...
-Feb 11, 2017 10:23:42 AM io.openshift.{app-name}
+Feb 11, 2017 10:23:42 AM io.openshift.{value-name-app}
 INFO: Greeting: Hello, Sarah
 ...
 ----
@@ -81,7 +81,7 @@ ifdef::built-for-thorntail[]
 [source,options="nowrap",subs="attributes+"]
 ----
 ...
-2018-02-11 11:12:31,158 INFO  [io.openshift.{app-name}] (default task-18) Hello, Sarah!
+2018-02-11 11:12:31,158 INFO  [io.openshift.{value-name-app}] (default task-18) Hello, Sarah!
 ...
 ----
 endif::[]

--- a/docs/topics/proc_accessing-jvm-metrics-using-the-hawtio-console-on-openshift.adoc
+++ b/docs/topics/proc_accessing-jvm-metrics-using-the-hawtio-console-on-openshift.adoc
@@ -26,7 +26,7 @@ oc get dc
 [subs="attributes+"]
 ----
 NAME         REVISION   DESIRED   CURRENT   TRIGGERED BY
-{app-name}   2          1         1         config,image(my-app:6)
+{value-name-app}   2          1         1         config,image(my-app:6)
 ...
 ----
 +
@@ -34,7 +34,7 @@ NAME         REVISION   DESIRED   CURRENT   TRIGGERED BY
 +
 [source,bash,subs="attributes+"]
 --
-oc edit dc/{app-name}
+oc edit dc/{value-name-app}
 --
 +
 . Add the following entry to the `ports` section of the template and save your changes:
@@ -56,7 +56,7 @@ spec:
 +
 [source,bash,subs="attributes+"]
 --
-oc rollout latest dc/{app-name}
+oc rollout latest dc/{value-name-app}
 --
 +
 // The above workflow can also be accomplished using the web console

--- a/docs/topics/proc_adding-new-guide.adoc
+++ b/docs/topics/proc_adding-new-guide.adoc
@@ -48,4 +48,4 @@ $ firefox html/my-new-guide.html
 
 In the command above, replace `firefox` with the browser of your choice.
 --
-. Write the content of the guide. When you are ready for some initial review and feedback, file a pull request to the `master` branch in the link:{link-repo-docs}[{repo-docs-name}] repository.
+. Write the content of the guide. When you are ready for some initial review and feedback, file a pull request to the `master` branch in the link:{link-repo-docs}[{name-repo-docs}] repository.

--- a/docs/topics/proc_authenticating-the-oc-cli-client.adoc
+++ b/docs/topics/proc_authenticating-the-oc-cli-client.adoc
@@ -15,7 +15,7 @@ To work with boosters on {parameter-deployment} using the `oc` command-line clie
 .Prerequisites
 
 ifdef::parameter-openshiftlocal[]
-* The URL of your running {launcher} instance and the user credentials of your {OpenShiftLocal}. For more information, see xref:getting-the-launcher-tool-url-and-credentials_{context}[].
+* The URL of your running {name-launcher} instance and the user credentials of your {OpenShiftLocal}. For more information, see xref:getting-the-launcher-tool-url-and-credentials_{context}[].
 endif::[]
 ifndef::parameter-openshiftlocal[]
 * An account at {parameter-deployment}.

--- a/docs/topics/proc_authenticating-the-oc-cli-client.adoc
+++ b/docs/topics/proc_authenticating-the-oc-cli-client.adoc
@@ -30,5 +30,5 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc login {link-oso-auth} --token=MYTOKEN
+$ oc login {value-url-oso-auth} --token=MYTOKEN
 ----

--- a/docs/topics/proc_configuring-your-application-to-use-vertx.adoc
+++ b/docs/topics/proc_configuring-your-application-to-use-vertx.adoc
@@ -39,8 +39,8 @@ Include the following properties in your `pom.xml` file to track the version of 
 <project>
   ...
   <properties>
-    <vertx.version>{VertXVersion}</vertx.version>
-    <vertx-maven-plugin.version>{VertXMvnPluginVersion}</vertx-maven-plugin.version>
+    <vertx.version>{version-vertx}</vertx.version>
+    <vertx-maven-plugin.version>{version-vertx-maven-plugin}</vertx-maven-plugin.version>
   </properties>
   ...
 </project>

--- a/docs/topics/proc_creating-a-github-personal-access-token.adoc
+++ b/docs/topics/proc_creating-a-github-personal-access-token.adoc
@@ -1,7 +1,7 @@
 [id='creating-a-github-personal-access-token_{context}']
 = Creating a GitHub personal access token
 
-To install the {launcher} tool on a {OpenShiftLocal}, you must provide the {launcher} tool with a GitHub personal access token. This enables the {launcher} tool to create booster applications and save them as Git repositories in your GitHub namespace.
+To install the {name-launcher} tool on a {OpenShiftLocal}, you must provide the {name-launcher} tool with a GitHub personal access token. This enables the {name-launcher} tool to create booster applications and save them as Git repositories in your GitHub namespace.
 
 .Prerequisites
 --
@@ -11,13 +11,13 @@ To install the {launcher} tool on a {OpenShiftLocal}, you must provide the {laun
 .Procedure
 . Using a web browser, navigate to `https://github.com/settings/tokens`.
 . Select _Generate new token._
-. Add a token description, for example `{launcher} tool on a {OpenShiftLocal}`.
+. Add a token description, for example `{name-launcher} tool on a {OpenShiftLocal}`.
 . Select the check boxes of the following parent scopes and all their children:
 ** `public_repo`
 ** `read:org`
 ** `admin:repo_hook`
 . Click  _Generate token_.
-. Save the hex code of the personal access token. You need this to complete the installation of the {launcher} tool on your {OpenShiftLocal}.
+. Save the hex code of the personal access token. You need this to complete the installation of the {name-launcher} tool on your {OpenShiftLocal}.
 +
-IMPORTANT: This hex code is displayed only once and cannot be retrieved after you leave the page. If you lose the code, you will need to create a new personal access token to install the {launcher} tool on a {OpenShiftLocal} again.
+IMPORTANT: This hex code is displayed only once and cannot be retrieved after you leave the page. If you lose the code, you will need to create a new personal access token to install the {name-launcher} tool on a {OpenShiftLocal} again.
 

--- a/docs/topics/proc_creating-a-nodejs-application.adoc
+++ b/docs/topics/proc_creating-a-nodejs-application.adoc
@@ -94,7 +94,7 @@ $ npm install nodeshift --save
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "openshift": "nodeshift --strictSSL=false --metadata.out=deployment-metadata.json --build.forcePull=true {nodeshiftNodeVersion}",
+    "openshift": "nodeshift --strictSSL=false --metadata.out=deployment-metadata.json --build.forcePull=true {version-node-nodeshift}",
     "start": "node app.js",
     ...
   }

--- a/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
+++ b/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
@@ -7,8 +7,8 @@ You can quickly create, build, and deploy a booster to a {OpenShiftLocal} using 
 
 * link:https://developers.redhat.com[Have a Red Hat Developers account]
 * link:https://github.com[Have a GitHub account]
-* link:{link-launcher-openshift-local-install-guide}[Have a {OpenShiftLocal} installed]
-* link:{link-launcher-openshift-local-install-guide}#installing-launcher-tool_minishift[Have the {launcher} tool installed to your {OpenShiftLocal}].
+* link:{link-guide-minishift-installation}[Have a {OpenShiftLocal} installed]
+* link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Have the {launcher} tool installed to your {OpenShiftLocal}].
 
 .Procedure
 
@@ -28,7 +28,7 @@ $ minishift console
 
 Take a look the different runtime guides to learn more about runtimes as well as their boosters:
 
-* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
-* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
-* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
-* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]
+* link:{link-guide-spring-boot}[{name-guide-spring-boot}]
+* link:{link-guide-vertx}[{name-guide-vertx}]
+* link:{link-guide-thorntail}[{name-guide-thorntail}]
+* link:{link-guide-nodejs}[{name-guide-nodejs}]

--- a/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
+++ b/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
@@ -28,7 +28,7 @@ $ minishift console
 
 Take a look the different runtime guides to learn more about runtimes as well as their boosters:
 
-* link:{link-spring-boot-runtime-guide}[{spring-boot-runtime-guide-name}]
-* link:{link-vertx-runtime-guide}[{vertx-runtime-guide-name}]
-* link:{link-wf-swarm-runtime-guide}[{wf-swarm-runtime-guide-name}]
-* link:{link-nodejs-runtime-guide}[{nodejs-runtime-guide-name}]
+* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
+* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
+* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
+* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]

--- a/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
+++ b/docs/topics/proc_creating-and-deploying-a-booster-using-your-openshiftlocal.adoc
@@ -1,19 +1,19 @@
 [id='creating-and-deploying-a-booster-using-your-openshiftlocal_{context}']
 = Creating and deploying a booster using your {OpenShiftLocal}
 
-You can quickly create, build, and deploy a booster to a {OpenShiftLocal} using the {launcher} tool. The {launcher} tool creates a new repository in your GitHub account containing the booster's code and deploys it to your {OpenShiftLocal}. It can also create a ZIP of the booster for you to download and run on your localhost.
+You can quickly create, build, and deploy a booster to a {OpenShiftLocal} using the {name-launcher} tool. The {name-launcher} tool creates a new repository in your GitHub account containing the booster's code and deploys it to your {OpenShiftLocal}. It can also create a ZIP of the booster for you to download and run on your localhost.
 
 .Prerequisites
 
 * link:https://developers.redhat.com[Have a Red Hat Developers account]
 * link:https://github.com[Have a GitHub account]
 * link:{link-guide-minishift-installation}[Have a {OpenShiftLocal} installed]
-* link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Have the {launcher} tool installed to your {OpenShiftLocal}].
+* link:{link-guide-minishift-installation}#installing-launcher-tool_minishift[Have the {name-launcher} tool installed to your {OpenShiftLocal}].
 
 .Procedure
 
-. Navigate to the {launcher} tool on your {OpenShiftLocal} using your browser.
-** Optionally, use the following command to open the Web Console of your {OpenShiftLocal} in your browser in order to navigate to your {launcher} tool:
+. Navigate to the {name-launcher} tool on your {OpenShiftLocal} using your browser.
+** Optionally, use the following command to open the Web Console of your {OpenShiftLocal} in your browser in order to navigate to your {name-launcher} tool:
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----

--- a/docs/topics/proc_creating-custom-booster-catalog.adoc
+++ b/docs/topics/proc_creating-custom-booster-catalog.adoc
@@ -2,7 +2,7 @@
 [id='creating-custom-booster-catalog_{context}']
 = Creating custom booster catalog
 
-By default, the {launcher} tool uses a booster catalog from the link:https://github.com/openshiftio/booster-catalog[openshiftio/booster-catalog] repository.
+By default, the {name-launcher} tool uses a booster catalog from the link:https://github.com/openshiftio/booster-catalog[openshiftio/booster-catalog] repository.
 If you do not want to use the default catalog, you can create one from scratch, or fork the default catalog and make changes to it. This chapter describes the procedure for modifying the default catalog.
 
 .Prerequisites

--- a/docs/topics/proc_creating-the-secured-booster-using-launcher.adoc
+++ b/docs/topics/proc_creating-the-secured-booster-using-launcher.adoc
@@ -1,15 +1,15 @@
 
 [id='creating-the-secured-booster-using-launcher_{context}']
-= Creating the {name-mission-secured} booster using {launcher}
+= Creating the {name-mission-secured} booster using {name-launcher}
 
 .Prerequisites
 
-* The URL and user credentials of your running {launcher} instance.
+* The URL and user credentials of your running {name-launcher} instance.
 For more information, see xref:getting-the-launcher-tool-url-and-credentials_{context}[].
 
 .Procedure
 
-* Navigate to the {launcher} URL in a browser and log in.
+* Navigate to the {name-launcher} URL in a browser and log in.
 * Follow the on-screen instructions to create your booster in {runtime}.
 When asked about which deployment type, select _I will build and run locally._
 * Follow on-screen instructions.

--- a/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
@@ -26,7 +26,7 @@ $ oc login OCP_URL --token=MYTOKEN
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.

--- a/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
@@ -50,7 +50,7 @@ $ npm install && npm run openshift
 .Additional resources
 Take a look at the different runtime guides to learn more about runtimes as well as their boosters:
 
-* link:{link-spring-boot-runtime-guide}[{spring-boot-runtime-guide-name}]
-* link:{link-vertx-runtime-guide}[{vertx-runtime-guide-name}]
-* link:{link-wf-swarm-runtime-guide}[{wf-swarm-runtime-guide-name}]
-* link:{link-nodejs-runtime-guide}[{nodejs-runtime-guide-name}]
+* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
+* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
+* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
+* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]

--- a/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
@@ -3,7 +3,7 @@
 
 .Prerequisites
 
-* Have a booster created using link:{link-launcher-oso}[{launcher-oso}] or the {launcher} tool in xref:creating-and-deploying-a-booster-using-your-openshiftlocal_{context}[a {OpenShiftLocal}].
+* Have a booster created using link:{link-launcher-oso}[{name-launcher-oso}] or the {name-launcher} tool in xref:creating-and-deploying-a-booster-using-your-openshiftlocal_{context}[a {OpenShiftLocal}].
 * Have access to an {OpenShiftContainerPlatform} Web console.
 * Have the `oc` CLI client installed.
 

--- a/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftcontainerplatform.adoc
@@ -50,7 +50,7 @@ $ npm install && npm run openshift
 .Additional resources
 Take a look at the different runtime guides to learn more about runtimes as well as their boosters:
 
-* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
-* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
-* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
-* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]
+* link:{link-guide-spring-boot}[{name-guide-spring-boot}]
+* link:{link-guide-vertx}[{name-guide-vertx}]
+* link:{link-guide-thorntail}[{name-guide-thorntail}]
+* link:{link-guide-nodejs}[{name-guide-nodejs}]

--- a/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
@@ -1,7 +1,7 @@
 [id='deploying-a-booster-to-openshiftonline_{context}']
 = Deploying a booster to {OpenShiftOnline}
-You can quickly create, build, and deploy a booster to {OpenShiftOnline} using link:{link-launcher-oso}[{launcher-oso}]. 
-link:{link-launcher-oso}[{launcher-oso}] creates a new repository in your GitHub account containing the booster's code and deploys it to your {OpenShiftOnline} account. 
+You can quickly create, build, and deploy a booster to {OpenShiftOnline} using link:{link-launcher-oso}[{name-launcher-oso}]. 
+link:{link-launcher-oso}[{name-launcher-oso}] creates a new repository in your GitHub account containing the booster's code and deploys it to your {OpenShiftOnline} account. 
 It can also create a ZIP of the booster for you to download and run on your localhost.
 
 
@@ -13,22 +13,22 @@ It can also create a ZIP of the booster for you to download and run on your loca
 * link:https://developers.redhat.com[Login to your Red Hat Developers account]
 
 .Procedure
-. Navigate to link:{link-launcher-oso}[{launcher-oso}] using your browser.
+. Navigate to link:{link-launcher-oso}[{name-launcher-oso}] using your browser.
 . Select _Launch your Project_.
 ** You may be prompted to log in to your Red Hat Developers account. If you are, click _Log in or register_ and complete the authentication steps.
-. You may be prompted to grant {launcher-oso} access to your GitHub and {OpenShiftOnline} accounts. This is a one-time action.
+. You may be prompted to grant {name-launcher-oso} access to your GitHub and {OpenShiftOnline} accounts. This is a one-time action.
 +
 [IMPORTANT]
 ====
-link:{link-launcher-oso}[{launcher-oso}] uses the link:https://sso.openshift.io/auth/realms/rh-developers-launch/account/identity[`rh-developers-launch` SSO realm] to connect your link:https://developers.redhat.com[Red Hat Developers account], your GitHub account, and your {OpenShiftOnline} account together. When you add these connections, link:{link-launcher-oso}[{launcher-oso}] is granted access to those accounts and is allowed to use those accounts when creating and deploying boosters.
+link:{link-launcher-oso}[{name-launcher-oso}] uses the link:https://sso.openshift.io/auth/realms/rh-developers-launch/account/identity[`rh-developers-launch` SSO realm] to connect your link:https://developers.redhat.com[Red Hat Developers account], your GitHub account, and your {OpenShiftOnline} account together. When you add these connections, link:{link-launcher-oso}[{name-launcher-oso}] is granted access to those accounts and is allowed to use those accounts when creating and deploying boosters.
 
 When connecting these three accounts together in `rh-developers-launch`, they may only be used with each other within the `rh-developers-launch` SSO realm. For example, if your GitHub account is associated with a different Red Hat Developers account within the `rh-developers-launch` SSO realm, you must deauthorize it from the other Red Hat Developers account or add a different GitHub account.
 
-At this time, you cannot use the `us-east-2` OpenShift Starter cluster with link:{link-launcher-oso}[{launcher-oso}]. This cluster is used with OpenShift.io and is configured differently.
+At this time, you cannot use the `us-east-2` OpenShift Starter cluster with link:{link-launcher-oso}[{name-launcher-oso}]. This cluster is used with OpenShift.io and is configured differently.
 ====
 +
 .. Click _Grant Access_.
-.. Click the _Add_ button next to the _GitHub_ field and authorize {launcher-oso} to access your GitHub account.
+.. Click the _Add_ button next to the _GitHub_ field and authorize {name-launcher-oso} to access your GitHub account.
 .. Click the _Add_ button next to the {OpenShiftOnline} cluster you use.
 . Follow the instructions to create a booster based on a mission, runtime, and target environment.
 . Open the `README.adoc` file in your booster's project and follow the instructions for building, deploying, and interacting with your booster.
@@ -37,7 +37,7 @@ At this time, you cannot use the `us-east-2` OpenShift Starter cluster with link
 --
 When you are done interacting with and xref:updating-your-booster-and-deploying-the-changes_{context}[updating] your booster, it is recommended to delete your project because the resources allocated to your {OpenShiftOnline} account are limited. For instructions, see the link:https://docs.openshift.com/online/dev_guide/projects.html#delete-a-project[Deleting a Project^] chapter of the {OpenShiftOnline} documentation. You can redeploy the booster later using the instructions in the relevant xref:oso-create-booster-related-info[runtime guide].
 
-You have link:https://docs.openshift.com/online/dev_guide/compute_resources.html#dev-quotas[quotas^] for your {OpenShiftOnline} account. If you exceed your account quota, you will not be able to launch new boosters using link:{link-launcher-oso}[{launcher-oso}]. The quota for your account varies depending on your subscription.
+You have link:https://docs.openshift.com/online/dev_guide/compute_resources.html#dev-quotas[quotas^] for your {OpenShiftOnline} account. If you exceed your account quota, you will not be able to launch new boosters using link:{link-launcher-oso}[{name-launcher-oso}]. The quota for your account varies depending on your subscription.
 --
 
 [#oso-create-booster-related-info]

--- a/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
@@ -44,7 +44,7 @@ You have link:https://docs.openshift.com/online/dev_guide/compute_resources.html
 .Additional resources
 See the runtime guides to learn more about runtimes and boosters that are available for them:
 
-* link:{link-spring-boot-runtime-guide}[{spring-boot-runtime-guide-name}]
-* link:{link-vertx-runtime-guide}[{vertx-runtime-guide-name}]
-* link:{link-wf-swarm-runtime-guide}[{wf-swarm-runtime-guide-name}]
-* link:{link-nodejs-runtime-guide}[{nodejs-runtime-guide-name}]
+* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
+* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
+* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
+* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]

--- a/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
+++ b/docs/topics/proc_deploying-a-booster-to-openshiftonline.adoc
@@ -44,7 +44,7 @@ You have link:https://docs.openshift.com/online/dev_guide/compute_resources.html
 .Additional resources
 See the runtime guides to learn more about runtimes and boosters that are available for them:
 
-* link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
-* link:{link-vertx-runtime-guide}[{name-guide-vertx}]
-* link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
-* link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]
+* link:{link-guide-spring-boot}[{name-guide-spring-boot}]
+* link:{link-guide-vertx}[{name-guide-vertx}]
+* link:{link-guide-thorntail}[{name-guide-thorntail}]
+* link:{link-guide-nodejs}[{name-guide-nodejs}]

--- a/docs/topics/proc_deploying-a-springboot-application-using-war-files.adoc
+++ b/docs/topics/proc_deploying-a-springboot-application-using-war-files.adoc
@@ -60,7 +60,7 @@ This ensures that the Spring Boot classes used to launch the application are inc
 ** `Main-Class: org.springframework.boot.loader.WarLauncher`
 ** `Spring-Boot-Classes: WEB-INF/classes/`
 ** `Spring-Boot-Lib: WEB-INF/lib/`
-** `Spring-Boot-Version: {SpringBootVersion}`
+** `Spring-Boot-Version: {version-spring-boot}`
 
 
 . Add the `ARTIFACT_COPY_ARGS` environment variable to the `pom.xml` file.

--- a/docs/topics/proc_deploying-an-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-application-to-openshift.adoc
@@ -34,7 +34,7 @@ $ oc login ...
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . In a terminal application, navigate to the directory containing your application:
@@ -59,11 +59,11 @@ This command uses the Fabric8 Maven Plugin to launch the link:{link-s2i-process}
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa               1/1       Running     0          58s
-{app-name}-s2i-1-build           0/1       Completed   0          2m
+{value-name-app}-1-aaaaa               1/1       Running     0          58s
+{value-name-app}-s2i-1-build           0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once it is fully deployed and started.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once it is fully deployed and started.
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -76,10 +76,10 @@ The letters at the end are generated when the pod is created.
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}         {app-name}-{project-name}.{os-route-hostname}      {app-name}      8080
+{value-name-app}         {value-name-app}-{value-name-project}.{value-route-openshift-hostname}      {value-name-app}      8080
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.
 
 . Using `curl` or your browser, verify your application is running in OpenShift.
 +

--- a/docs/topics/proc_deploying-an-existing-wildflyswarm-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-existing-wildflyswarm-application-to-openshift.adoc
@@ -22,7 +22,7 @@ You can easily deploy your existing application to OpenShift using the Fabric8 M
       <plugin>
         <groupId>io.fabric8</groupId>
         <artifactId>fabric8-maven-plugin</artifactId>
-        <version>{Fabric8MavenPluginVersion}</version>
+        <version>{version-fabric8-maven-plugin}</version>
         <executions>
           <execution>
             <goals>

--- a/docs/topics/proc_deploying-the-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-the-booster-to-openshiftcontainerplatform.adoc
@@ -11,7 +11,7 @@ The process of creating and deploying boosters to {OpenshiftContainerPlatform} i
 
 .Prerequisites
 
-* The booster created using link:{link-launcher-oso}[{launcher-oso}] or link:{link-openshift-local-guide}[the {launcher} tool].
+* The booster created using link:{link-launcher-oso}[{launcher-oso}] or link:{link-guide-minishift-installation}[the {launcher} tool].
 
 .Procedure
 

--- a/docs/topics/proc_deploying-the-booster-to-openshiftcontainerplatform.adoc
+++ b/docs/topics/proc_deploying-the-booster-to-openshiftcontainerplatform.adoc
@@ -11,7 +11,7 @@ The process of creating and deploying boosters to {OpenshiftContainerPlatform} i
 
 .Prerequisites
 
-* The booster created using link:{link-launcher-oso}[{launcher-oso}] or link:{link-guide-minishift-installation}[the {launcher} tool].
+* The booster created using link:{link-launcher-oso}[{name-launcher-oso}] or link:{link-guide-minishift-installation}[the {name-launcher} tool].
 
 .Procedure
 

--- a/docs/topics/proc_deploying-the-booster-using-launcher-oso.adoc
+++ b/docs/topics/proc_deploying-the-booster-using-launcher-oso.adoc
@@ -9,7 +9,7 @@
 // Rationale: This procedure is identical in all deployments
 
 [id='deploying-the-booster-using-launcher-oso_{context}']
-= Deploying the booster using {launcher-oso}
+= Deploying the booster using {name-launcher-oso}
 
 .Prerequisites
 * An account at {parameter-deployment}.

--- a/docs/topics/proc_deploying-the-booster-using-the-launcher-tool.adoc
+++ b/docs/topics/proc_deploying-the-booster-using-the-launcher-tool.adoc
@@ -8,11 +8,11 @@
 // Rationale: This procedure is identical in all deployments
 
 [id='deploying-the-booster-using-the-launcher-tool_{context}']
-= Deploying the booster using the {launcher} tool
+= Deploying the booster using the {name-launcher} tool
 
 .Prerequisites
 
-* The URL of your running {launcher} instance and the user credentials of your {OpenShiftLocal}.
+* The URL of your running {name-launcher} instance and the user credentials of your {OpenShiftLocal}.
 For more information, see xref:getting-the-launcher-tool-url-and-credentials_{context}[].
 
 .Procedure

--- a/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
@@ -17,21 +17,21 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.
@@ -68,10 +68,10 @@ endif::built-for-nodejs[]
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
 cache-server-123456789-aaaaa             1/1       Running     0          8m
-{app-name}-cutename-1-bbbbb       1/1       Running     0          4m
-{app-name}-cutename-s2i-1-build   0/1       Completed   0          7m
-{app-name}-greeting-1-ccccc       1/1       Running     0          3m
-{app-name}-greeting-s2i-1-build   0/1       Completed   0          3m
+{value-name-app}-cutename-1-bbbbb       1/1       Running     0          4m
+{value-name-app}-cutename-s2i-1-build   0/1       Completed   0          7m
+{value-name-app}-greeting-1-ccccc       1/1       Running     0          3m
+{value-name-app}-greeting-s2i-1-build   0/1       Completed   0          3m
 ----
 +
 Your 3 pods should have a status of `Running` once they are fully deployed and started.
@@ -83,9 +83,9 @@ Your 3 pods should have a status of `Running` once they are fully deployed and s
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}-cutename   {app-name}-cutename-{project-name}.{os-route-hostname}             {app-name}-cutename   8080                    None
-{app-name}-greeting   {app-name}-greeting-{project-name}.{os-route-hostname}             {app-name}-greeting   8080                    None
+{value-name-app}-cutename   {value-name-app}-cutename-{value-name-project}.{value-route-openshift-hostname}             {value-name-app}-cutename   8080                    None
+{value-name-app}-greeting   {value-name-app}-greeting-{value-name-project}.{value-route-openshift-hostname}             {value-name-app}-greeting   8080                    None
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-greeting-{project-name}.{os-route-hostname}` as the base URL to access the greeting service.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-greeting-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the greeting service.
 

--- a/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-cache-booster-using-the-oc-cli-client.adoc
@@ -7,7 +7,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
@@ -23,21 +23,21 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new OpenShift project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.
@@ -72,15 +72,15 @@ endif::built-for-nodejs[]
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-greeting-1-aaaaa     1/1       Running   0           17s
-{app-name}-greeting-1-deploy    0/1       Completed 0           22s
-{app-name}-name-1-aaaaa         1/1       Running   0           14s
-{app-name}-name-1-deploy        0/1       Completed 0           28s
+{value-name-app}-greeting-1-aaaaa     1/1       Running   0           17s
+{value-name-app}-greeting-1-deploy    0/1       Completed 0           22s
+{value-name-app}-name-1-aaaaa         1/1       Running   0           14s
+{value-name-app}-name-1-deploy        0/1       Completed 0           28s
 ----
 +
-Both the `{app-name}-greeting-1-aaaaa` and `{app-name}-name-1-aaaaa` pods should have a status of `Running` once they are fully deployed and started. 
+Both the `{value-name-app}-greeting-1-aaaaa` and `{value-name-app}-name-1-aaaaa` pods should have a status of `Running` once they are fully deployed and started. 
 You should also wait for your pods to be ready before proceeding, which is shown in the `READY` column. 
-For example, `{app-name}-greeting-1-aaaaa` is ready when the `READY` column is `1/1`.
+For example, `{value-name-app}-greeting-1-aaaaa` is ready when the `READY` column is `1/1`.
 Your specific pod names will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -93,9 +93,9 @@ The letters at the end are generated when the pod is created.
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}-greeting   {app-name}-greeting-{project-name}.{os-route-hostname}            {app-name}-greeting   8080                    None
-{app-name}-name       {app-name}-name-{project-name}.{os-route-hostname}            {app-name}-name       8080                    None
+{value-name-app}-greeting   {value-name-app}-greeting-{value-name-project}.{value-route-openshift-hostname}            {value-name-app}-greeting   8080                    None
+{value-name-app}-name       {value-name-app}-name-{value-name-project}.{value-route-openshift-hostname}            {value-name-app}-name       8080                    None
 ----
 +
 
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-greeting-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-greeting-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.

--- a/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-circuit-breaker-booster-using-the-oc-cli-client.adoc
@@ -13,7 +13,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -24,21 +24,21 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new OpenShift project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 ifdef::built-for-vertx,built-for-spring-boot,built-for-nodejs[]
@@ -156,13 +156,13 @@ endif::built-for-nodejs[]
 ----
 $ oc get pods -w
 NAME                                       READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa               1/1       Running     0          58s
-{app-name}-s2i-1-build           0/1       Completed   0          2m
+{value-name-app}-1-aaaaa               1/1       Running     0          58s
+{value-name-app}-s2i-1-build           0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
 ifdef::built-for-vertx[]
-You should also wait for your pod to be _ready_ before proceeding, which is shown in the `READY` column. For example, `{app-name}-1-aaaaa` is _ready_ when the `READY` column is `1/1`.
+You should also wait for your pod to be _ready_ before proceeding, which is shown in the `READY` column. For example, `{value-name-app}-1-aaaaa` is _ready_ when the `READY` column is `1/1`.
 endif::built-for-vertx[]
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
@@ -176,7 +176,7 @@ The letters at the end are generated when the pod is created.
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}         {app-name}-{project-name}.{os-route-hostname}      {app-name}      8080
+{value-name-app}         {value-name-app}-{value-name-project}.{value-route-openshift-hostname}      {value-name-app}      8080
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.

--- a/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-configmap-booster-using-the-oc-cli-client.adoc
@@ -14,7 +14,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
@@ -24,21 +24,21 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new OpenShift project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.
@@ -96,11 +96,11 @@ endif::built-for-nodejs[]
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa       1/1       Running     0          58s
-{app-name}-s2i-1-build   0/1       Completed   0          2m
+{value-name-app}-1-aaaaa       1/1       Running     0          58s
+{value-name-app}-s2i-1-build   0/1       Completed   0          2m
 ----
 +
-Your `{app-name}-1-aaaaa` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
+Your `{value-name-app}-1-aaaaa` pod should have a status of `Running` and should be indicated as ready once it is fully deployed and started.
 
 . Once your booster is deployed and started, determine its route.
 +
@@ -109,7 +109,7 @@ Your `{app-name}-1-aaaaa` pod should have a status of `Running` and should be in
 ----
 $ oc get routes
 NAME                 HOST/PORT                                     PATH      SERVICES             PORT      TERMINATION
-{app-name}   {app-name}-{project-name}.{os-route-hostname}      {app-name}   8080
+{value-name-app}   {value-name-app}-{value-name-project}.{value-route-openshift-hostname}      {value-name-app}   8080
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.

--- a/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-crud-booster-using-the-oc-cli-client.adoc
@@ -14,7 +14,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
@@ -23,20 +23,20 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 . Create a new OpenShift project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.
@@ -69,11 +69,11 @@ endif::built-for-nodejs[]
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa               1/1       Running     0          58s
-{app-name}-s2i-1-build           0/1       Completed   0          2m
+{value-name-app}-1-aaaaa               1/1       Running     0          58s
+{value-name-app}-s2i-1-build           0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started. You should also wait for your pod to be ready before proceeding, which is shown in the `READY` column. For example, `{app-name}-1-aaaaa` is ready when the `READY` column is `1/1`.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started. You should also wait for your pod to be ready before proceeding, which is shown in the `READY` column. For example, `{value-name-app}-1-aaaaa` is ready when the `READY` column is `1/1`.
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -86,7 +86,7 @@ The letters at the end are generated when the pod is created.
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}         {app-name}-{project-name}.{os-route-hostname}      {app-name}      8080
+{value-name-app}         {value-name-app}-{value-name-project}.{value-route-openshift-hostname}      {value-name-app}      8080
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.

--- a/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-health-check-booster-using-the-oc-cli-client.adoc
@@ -13,7 +13,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
@@ -23,21 +23,21 @@ endif::[]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new project in OpenShift.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.
@@ -70,11 +70,11 @@ endif::built-for-nodejs[]
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa               1/1       Running     0          58s
-{app-name}-s2i-1-build           0/1       Completed   0          2m
+{value-name-app}-1-aaaaa               1/1       Running     0          58s
+{value-name-app}-s2i-1-build           0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once it is fully deployed and started.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once it is fully deployed and started.
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -87,7 +87,7 @@ The letters at the end are generated when the pod is created.
 ----
 $ oc get routes
 NAME                 HOST/PORT                                                     PATH      SERVICES        PORT      TERMINATION
-{app-name}         {app-name}-{project-name}.{os-route-hostname}      {app-name}      8080
+{value-name-app}         {value-name-app}-{value-name-project}.{value-route-openshift-hostname}      {value-name-app}      8080
 ----
 +
-The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{app-name}-{project-name}.{os-route-hostname}` as the base URL to access the application.
+The route information of a pod gives you the base URL which you use to access it. In the example above, you would use `\http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}` as the base URL to access the application.

--- a/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-http-api-booster-using-the-oc-cli-client.adoc
@@ -13,7 +13,7 @@
 ifndef::parameter-openshiftlocal[For more information, see xref:deploying-the-booster-using-launcher-oso_{context}[].]
 ifdef::parameter-openshiftlocal[]
 For more information, see xref:deploying-the-booster-using-the-launcher-tool_{context}[].
-* Your {launcher} tool URL.
+* Your {name-launcher} tool URL.
 endif::[]
 
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].

--- a/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
@@ -20,21 +20,21 @@ ifndef::parameter-ocp[* Your {launcher} URL.]
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git clone git@github.com:USERNAME/{project-name}.git
+$ git clone git@github.com:USERNAME/{value-name-project}.git
 ----
 +
 Alternatively, if you downloaded a ZIP file of your project, extract it.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ unzip {project-name}.zip
+$ unzip {value-name-project}.zip
 ----
 
 . Create a new OpenShift project.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc new-project {project-name}
+$ oc new-project {value-name-project}
 ----
 
 . Navigate to the root directory of your booster.

--- a/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
+++ b/docs/topics/proc_deploying-the-secured-booster-using-the-oc-cli-client.adoc
@@ -9,10 +9,10 @@
 
 .Prerequisites
 
-* The booster application created using the {launcher} tool on a {OpenShiftLocal}.
+* The booster application created using the {name-launcher} tool on a {OpenShiftLocal}.
 ifndef::parameter-ocp[For more information, see xref:creating-the-secured-booster-using-launcher_{context}[].]
 
-ifndef::parameter-ocp[* Your {launcher} URL.]
+ifndef::parameter-ocp[* Your {name-launcher} URL.]
 * The `oc` client authenticated. For more information, see xref:authenticating-the-oc-cli-client_{context}[].
 
 .Procedure

--- a/docs/topics/proc_exposing-application-metrics-using-prometheus-on-node-js.adoc
+++ b/docs/topics/proc_exposing-application-metrics-using-prometheus-on-node-js.adoc
@@ -101,7 +101,7 @@ app.get('/metrics', (req, res) => {
   res.end(client.register.metrics());
 })
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+app.listen(port, () => console.log(`Example app listening on port ${parameter-port}!`))
 ----
 
 . Start your application:

--- a/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
+++ b/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
@@ -12,7 +12,7 @@ You need the {launcher} tool URL and user credentials to create and deploy boost
 
 .Prerequisites
 
-* The {launcher} tool installed, configured, and running. For more information, see the link:{link-launcher-openshift-local-install-guide}[{name-guide-minishift-installation}] guide.
+* The {launcher} tool installed, configured, and running. For more information, see the link:{link-guide-minishift-installation}[{name-guide-minishift-installation}] guide.
 
 .Procedure
 

--- a/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
+++ b/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
@@ -12,7 +12,7 @@ You need the {launcher} tool URL and user credentials to create and deploy boost
 
 .Prerequisites
 
-* The {launcher} tool installed, configured, and running. For more information, see the link:{link-launcher-openshift-local-install-guide}[{minishift-installation-guide-name}] guide.
+* The {launcher} tool installed, configured, and running. For more information, see the link:{link-launcher-openshift-local-install-guide}[{name-guide-minishift-installation}] guide.
 
 .Procedure
 

--- a/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
+++ b/docs/topics/proc_getting-the-launcher-tool-url-and-credentials.adoc
@@ -6,18 +6,18 @@
 
 
 [id='getting-the-launcher-tool-url-and-credentials_{context}']
-= Getting the {launcher} tool URL and credentials
+= Getting the {name-launcher} tool URL and credentials
 
-You need the {launcher} tool URL and user credentials to create and deploy boosters on {OpenShiftLocal}. This information is provided when the {OpenShiftLocal} is started.
+You need the {name-launcher} tool URL and user credentials to create and deploy boosters on {OpenShiftLocal}. This information is provided when the {OpenShiftLocal} is started.
 
 .Prerequisites
 
-* The {launcher} tool installed, configured, and running. For more information, see the link:{link-guide-minishift-installation}[{name-guide-minishift-installation}] guide.
+* The {name-launcher} tool installed, configured, and running. For more information, see the link:{link-guide-minishift-installation}[{name-guide-minishift-installation}] guide.
 
 .Procedure
 
 . Navigate to the console where you started {OpenShiftLocal}.
-. Check the console output for the URL and user credentials you can use to access the running {launcher}:
+. Check the console output for the URL and user credentials you can use to access the running {name-launcher}:
 +
 .Example Console Output from a {OpenShiftLocal} Startup
 [source,bash,options="nowrap",subs="attributes+"]

--- a/docs/topics/proc_getting-the-secured-booster-api-endpoint.adoc
+++ b/docs/topics/proc_getting-the-secured-booster-api-endpoint.adoc
@@ -45,4 +45,4 @@ A sample output is shown in the following table:
 --
 +
 In the above example, the booster endpoint would be `\http://PROJECT_ID-myproject.LOCAL_OPENSHIFT_HOSTNAME`.
-`PROJECT_ID` is based on the name you entered when generating your booster using link:{link-launcher-oso}[{launcher-oso}] or the {launcher} tool.
+`PROJECT_ID` is based on the name you entered when generating your booster using link:{link-launcher-oso}[{name-launcher-oso}] or the {name-launcher} tool.

--- a/docs/topics/proc_git-workflow-for-making-changes.adoc
+++ b/docs/topics/proc_git-workflow-for-making-changes.adoc
@@ -2,19 +2,19 @@
 [id='git-workflow-for-making-changes_{context}']
 = Git workflow for making changes
 
-When making contributions, follow the standard link:https://guides.github.com/introduction/flow/[GitHub flow]. Below, you will find more details about the steps that are required in the _{repo-docs-name}_ repository.
+When making contributions, follow the standard link:https://guides.github.com/introduction/flow/[GitHub flow]. Below, you will find more details about the steps that are required in the _{name-repo-docs}_ repository.
 
 WARNING: Do not edit files in the `$REPO_HOME/docs/topics/thorntail` directory, always submit a pull request to the link:{link-repo-wildfly-swarm}[{WildFlySwarm} repository] and synchronize the files afterwards.
 
 .Prerequisites
 
 * A GitHub account with GPG. For more information, see xref:_accounts[].
-* The {repo-docs-name} repository cloned and xref:_before_you_start[Git hooks set up].
+* The {name-repo-docs} repository cloned and xref:_before_you_start[Git hooks set up].
 
 .Procedure
 
 .Contributor Workflow
-. Create a topic branch in your personal fork of the _{repo-docs-name}_ repository. If you want to resolve a particular issue with your changes, name the branch `issue-$ID`, where `$ID` is the numerical ID of the issue.
+. Create a topic branch in your personal fork of the _{name-repo-docs}_ repository. If you want to resolve a particular issue with your changes, name the branch `issue-$ID`, where `$ID` is the numerical ID of the issue.
 . Commit and push your changes to the topic branch. Verify your changes:
 ** Preview the build locally. For more information, see xref:building-locally_{context}[].
 ** Optionally validate the books. This step is done automatically by a commit hook at commit time, but you can validate the books manually at any time. Execute the following script:

--- a/docs/topics/proc_importing-your-booster-code-to-red-hat-jboss-developer-studio.adoc
+++ b/docs/topics/proc_importing-your-booster-code-to-red-hat-jboss-developer-studio.adoc
@@ -6,7 +6,7 @@ Importing your booster's code creates a project in {DevStudio} and enables you t
 
 .Prerequisites
 
-* Your booster created and downloaded from link:{link-launcher-oso}[{launcher-oso}].
+* Your booster created and downloaded from link:{link-launcher-oso}[{name-launcher-oso}].
 * {DevStudio} running.
 
 .Procedure

--- a/docs/topics/proc_importing-your-booster-code-to-visual-studio-code.adoc
+++ b/docs/topics/proc_importing-your-booster-code-to-visual-studio-code.adoc
@@ -6,7 +6,7 @@ You can add the project folder of your booster code to an existing workspace in 
 
 .Prerequisites
 
-* Your booster created and downloaded from link:{link-launcher-oso}[{launcher-oso}].
+* Your booster created and downloaded from link:{link-launcher-oso}[{name-launcher-oso}].
 * Visual Studio Code running.
 
 .Procedure

--- a/docs/topics/proc_installing-a-openshiftlocal.adoc
+++ b/docs/topics/proc_installing-a-openshiftlocal.adoc
@@ -2,7 +2,7 @@
 [#installing-a-openshiftlocal]
 = Installing a {OpenShiftLocal}
 
-To use the {launcher} tool on a local cloud, you must have a {OpenShiftLocal} installed and configured. You can use either {Minishift} or {CDK}.
+To use the {name-launcher} tool on a local cloud, you must have a {OpenShiftLocal} installed and configured. You can use either {Minishift} or {CDK}.
 
 .Prerequisites
 

--- a/docs/topics/proc_installing-launcher-tool-addon.adoc
+++ b/docs/topics/proc_installing-launcher-tool-addon.adoc
@@ -66,9 +66,9 @@ launcher   launcher-rhoarpad.{osl-route-hostname}             launcher-frontend 
 This is the same service as `{link-launcher-oso}` but running in a {OpenShiftLocal}.
 
 .Additional Resources
-* See the link:{link-getting-started-guide}[{getting-started-guide-name}] for a walk-through of running a booster application.
+* See the link:{link-getting-started-guide}[{name-guide-getting-started}] for a walk-through of running a booster application.
 * Read the runtime guides for an overview of the runtimes and their boosters:
-** link:{link-spring-boot-runtime-guide}[{spring-boot-runtime-guide-name}]
-** link:{link-vertx-runtime-guide}[{vertx-runtime-guide-name}]
-** link:{link-wf-swarm-runtime-guide}[{wf-swarm-runtime-guide-name}]
-** link:{link-nodejs-runtime-guide}[{nodejs-runtime-guide-name}]
+** link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
+** link:{link-vertx-runtime-guide}[{name-guide-vertx}]
+** link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
+** link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]

--- a/docs/topics/proc_installing-launcher-tool-addon.adoc
+++ b/docs/topics/proc_installing-launcher-tool-addon.adoc
@@ -6,8 +6,8 @@
 // booster catalog.
 
 [id='installing-launcher-tool-as-a-osl-addon_{context}']
-= Installing {launcher} Tool as a {Minishift} add-on
-link:https://docs.openshift.org/latest/minishift/using/addons.html[Add-ons] enable you to extend the behavior of {OpenShiftLocal}, and the {launcher} tool link:https://github.com/minishift/minishift-addons/tree/master/add-ons/fabric8-launcher[provides an add-on] as an installation option.
+= Installing {name-launcher} Tool as a {Minishift} add-on
+link:https://docs.openshift.org/latest/minishift/using/addons.html[Add-ons] enable you to extend the behavior of {OpenShiftLocal}, and the {name-launcher} tool link:https://github.com/minishift/minishift-addons/tree/master/add-ons/fabric8-launcher[provides an add-on] as an installation option.
 
 .Prerequisites
 * xref:starting-and-configuring-the-openshiftlocal-for-the-launcher-tool_{context}[{OpenShiftLocal} running].
@@ -23,7 +23,7 @@ $ minishift config set memory 4096
 $ minishift start
 ----
 
-. Download and install the {launcher} add-on.
+. Download and install the {name-launcher} add-on.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -35,9 +35,9 @@ $ minishift addons apply fabric8-launcher \
 ----
 <1> Use your GitHub username and personal access token
 +
-Installing the add-on creates a new project called `rhoarpad` where the {launcher} tool runs.
+Installing the add-on creates a new project called `rhoarpad` where the {name-launcher} tool runs.
 
-. Monitor the status of the {launcher} tool until it completes start up.
+. Monitor the status of the {name-launcher} tool until it completes start up.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -52,7 +52,7 @@ launcher-backend-2-aaaaa       0/1       Running             0         5s
 launcher-frontend-2-aaaaa      0/1       Running             0         6s
 ----
 
-. Obtain the route of your {launcher} tool.
+. Obtain the route of your {name-launcher} tool.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -61,7 +61,7 @@ NAME       HOST/PORT                                PATH      SERVICES          
 launcher   launcher-rhoarpad.{value-route-osl-hostname}             launcher-frontend   <all>                   None
 ----
 
-. Navigate to your {launcher} tool and start using your {launcher} tool to launch booster applications.
+. Navigate to your {name-launcher} tool and start using your {name-launcher} tool to launch booster applications.
 +
 This is the same service as `{link-launcher-oso}` but running in a {OpenShiftLocal}.
 

--- a/docs/topics/proc_installing-launcher-tool-addon.adoc
+++ b/docs/topics/proc_installing-launcher-tool-addon.adoc
@@ -11,7 +11,7 @@ link:https://docs.openshift.org/latest/minishift/using/addons.html[Add-ons] enab
 
 .Prerequisites
 * xref:starting-and-configuring-the-openshiftlocal-for-the-launcher-tool_{context}[{OpenShiftLocal} running].
-* A link:{link-launcher-openshift-local-install-guide}#creating-a-github-personal-access-token_minishift[GitHub personal access token].
+* A link:{link-guide-minishift-installation}#creating-a-github-personal-access-token_minishift[GitHub personal access token].
 
 .Procedure
 
@@ -66,9 +66,9 @@ launcher   launcher-rhoarpad.{value-route-osl-hostname}             launcher-fro
 This is the same service as `{link-launcher-oso}` but running in a {OpenShiftLocal}.
 
 .Additional Resources
-* See the link:{link-getting-started-guide}[{name-guide-getting-started}] for a walk-through of running a booster application.
+* See the link:{link-guide-getting-started}[{name-guide-getting-started}] for a walk-through of running a booster application.
 * Read the runtime guides for an overview of the runtimes and their boosters:
-** link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
-** link:{link-vertx-runtime-guide}[{name-guide-vertx}]
-** link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
-** link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]
+** link:{link-guide-spring-boot}[{name-guide-spring-boot}]
+** link:{link-guide-vertx}[{name-guide-vertx}]
+** link:{link-guide-thorntail}[{name-guide-thorntail}]
+** link:{link-guide-nodejs}[{name-guide-nodejs}]

--- a/docs/topics/proc_installing-launcher-tool-addon.adoc
+++ b/docs/topics/proc_installing-launcher-tool-addon.adoc
@@ -58,7 +58,7 @@ launcher-frontend-2-aaaaa      0/1       Running             0         6s
 ----
 $ oc get routes
 NAME       HOST/PORT                                PATH      SERVICES            PORT      TERMINATION   WILDCARD
-launcher   launcher-rhoarpad.{osl-route-hostname}             launcher-frontend   <all>                   None
+launcher   launcher-rhoarpad.{value-route-osl-hostname}             launcher-frontend   <all>                   None
 ----
 
 . Navigate to your {launcher} tool and start using your {launcher} tool to launch booster applications.

--- a/docs/topics/proc_installing-launcher-tool-manually.adoc
+++ b/docs/topics/proc_installing-launcher-tool-manually.adoc
@@ -12,7 +12,7 @@ Install a local customized instance of the {launcher} tool, which allows you to 
 
 .Prerequisites
 * {OpenShiftLocal} installed and running.
-* A link:{link-launcher-openshift-local-install-guide}#creating-a-github-personal-access-token_minishift[GitHub personal access token].
+* A link:{link-guide-minishift-installation}#creating-a-github-personal-access-token_minishift[GitHub personal access token].
 
 .Procedure
 . Open the {OpenShiftLocal} Web console and log in.
@@ -63,9 +63,9 @@ A new browser tab opens with the {launcher} tool. This is the same service as `{
 . Start using your {launcher} tool to launch booster applications.
 
 .Additional resources
-* See the link:{link-getting-started-guide}[{name-guide-getting-started}] for a walk-through of running a booster application.
+* See the link:{link-guide-getting-started}[{name-guide-getting-started}] for a walk-through of running a booster application.
 * Read the runtime guides for an overview of the runtimes and their boosters:
-** link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
-** link:{link-vertx-runtime-guide}[{name-guide-vertx}]
-** link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
-** link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]
+** link:{link-guide-spring-boot}[{name-guide-spring-boot}]
+** link:{link-guide-vertx}[{name-guide-vertx}]
+** link:{link-guide-thorntail}[{name-guide-thorntail}]
+** link:{link-guide-nodejs}[{name-guide-nodejs}]

--- a/docs/topics/proc_installing-launcher-tool-manually.adoc
+++ b/docs/topics/proc_installing-launcher-tool-manually.adoc
@@ -6,9 +6,9 @@
 // booster catalog.
 
 [id='installing-launcher-tool-manually_{context}']
-= Installing {launcher} tool manually
+= Installing {name-launcher} tool manually
 
-Install a local customized instance of the {launcher} tool, which allows you to test the functionality or make modifications to the service using a web interface.
+Install a local customized instance of the {name-launcher} tool, which allows you to test the functionality or make modifications to the service using a web interface.
 
 .Prerequisites
 * {OpenShiftLocal} installed and running.
@@ -16,7 +16,7 @@ Install a local customized instance of the {launcher} tool, which allows you to 
 
 .Procedure
 . Open the {OpenShiftLocal} Web console and log in.
-. Click _New Project_ to create a new OpenShift project to house the {launcher} tool.
+. Click _New Project_ to create a new OpenShift project to house the {name-launcher} tool.
 +
 image::minishift_newproject.png[New Project Button]
 
@@ -30,7 +30,7 @@ image::minishift_projectconfig.png[New Project Config]
 +
 image::minishift_yamljson.png[Import YAML/JSON]
 
-. Copy the contents of link:{link-launcher-yaml}[the current {launcher} template from the GitHub repository^] and paste it into the text box provided.
+. Copy the contents of link:{link-launcher-yaml}[the current {name-launcher} template from the GitHub repository^] and paste it into the text box provided.
 
 . Click _Create_, ensure that only the _Process the template_ option is selected, and click _Continue_.
 +
@@ -43,7 +43,7 @@ image::minishift_processtemplate.png[Process Template]
 ** OpenShift username and password from your {OpenShiftLocal}, for example `developer` for the username and password.
 ** _KeyCloak URL_ and _KeyCloak Realm_ **MUST** be cleared out.
 +
-WARNING: You must clear these fields out for the {launcher} tool on your {OpenShiftLocal} to be configured correctly.
+WARNING: You must clear these fields out for the {name-launcher} tool on your {OpenShiftLocal} to be configured correctly.
 
 ifndef::parameter-custom-catalog[** Do not modify _Catalog Git Repository_ and _Catalog Git Reference_ unless you are developing against a specific catalog repository.]
 ifdef::parameter-custom-catalog[** Set _Catalog Git Repository_ to the repository with the catalog that you are testing. Set _Catalog Git Reference_ to the branch in that repository you are testing.]
@@ -52,15 +52,15 @@ ifdef::parameter-custom-catalog[** Set _Catalog Git Repository_ to the repositor
 
 . Click `Create` to complete the setup. You will see a screen confirming that the service has been created. Click _Continue to overview_.
 
-. On the overview page, wait and confirm that the four pods for the {launcher} tool have completed starting up.
+. On the overview page, wait and confirm that the four pods for the {name-launcher} tool have completed starting up.
 +
-image::minishift_launcher_booting.png[{launcher} booting]
+image::minishift_launcher_booting.png[{name-launcher} booting]
 
 . When all pods are running, click the link at the top of all pods, which typically ends in `nip.io`. 
 +
-A new browser tab opens with the {launcher} tool. This is the same service as `{link-launcher-oso}` but running in a {OpenShiftLocal}.
+A new browser tab opens with the {name-launcher} tool. This is the same service as `{link-launcher-oso}` but running in a {OpenShiftLocal}.
 
-. Start using your {launcher} tool to launch booster applications.
+. Start using your {name-launcher} tool to launch booster applications.
 
 .Additional resources
 * See the link:{link-guide-getting-started}[{name-guide-getting-started}] for a walk-through of running a booster application.

--- a/docs/topics/proc_installing-launcher-tool-manually.adoc
+++ b/docs/topics/proc_installing-launcher-tool-manually.adoc
@@ -63,9 +63,9 @@ A new browser tab opens with the {launcher} tool. This is the same service as `{
 . Start using your {launcher} tool to launch booster applications.
 
 .Additional resources
-* See the link:{link-getting-started-guide}[{getting-started-guide-name}] for a walk-through of running a booster application.
+* See the link:{link-getting-started-guide}[{name-guide-getting-started}] for a walk-through of running a booster application.
 * Read the runtime guides for an overview of the runtimes and their boosters:
-** link:{link-spring-boot-runtime-guide}[{spring-boot-runtime-guide-name}]
-** link:{link-vertx-runtime-guide}[{vertx-runtime-guide-name}]
-** link:{link-wf-swarm-runtime-guide}[{wf-swarm-runtime-guide-name}]
-** link:{link-nodejs-runtime-guide}[{nodejs-runtime-guide-name}]
+** link:{link-spring-boot-runtime-guide}[{name-guide-spring-boot}]
+** link:{link-vertx-runtime-guide}[{name-guide-vertx}]
+** link:{link-wf-swarm-runtime-guide}[{name-guide-thorntail}]
+** link:{link-nodejs-runtime-guide}[{name-guide-nodejs}]

--- a/docs/topics/proc_interacting-with-the-circuit-breaker-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-circuit-breaker-booster.adoc
@@ -12,19 +12,19 @@
 
 Once you have the {runtime} booster deployed, you have the following services running:
 
-`{app-name}-name`::
+`{value-name-app}-name`::
 Exposes the following endpoints:
 
 * the `/api/name` endpoint, which returns a name when this service is working, and an error when this service is set up to demonstrate failure.
 
 * the `/api/state` endpoint, which controls the behavior of the `/api/name` endpoint and determines whether the service works correctly or demonstrates failure.
 
-`{app-name}-greeting`::
+`{value-name-app}-greeting`::
 Exposes the following endpoints:
 
 * the `/api/greeting` endpoint that you can call to get a personalized greeting response.
 +
-When you call the `/api/greeting` endpoint, it issues a call against the `/api/name` endpoint of the `{app-name}-name` service as part of processing your request.
+When you call the `/api/greeting` endpoint, it issues a call against the `/api/name` endpoint of the `{value-name-app}-name` service as part of processing your request.
 The call made against the `/api/name` endpoint is protected by the Circuit Breaker.
 +
 If the remote endpoint is available, the `name` service responds with an HTTP code `200` (`OK`) and you receive the following greeting from the `/api/greeting` endpoint:
@@ -50,27 +50,27 @@ endif::[]
 The following steps demonstrate how to verify the availability of the service, simulate a failure and receive a fallback response.
 
 //TODO: add a warning not to use `http` as it may contain cached responses from the remote endpoint.
-. Use `curl` to execute a `GET` request against the `{app-name}-greeting` service. You can also use the `Invoke` button in the web interface to do this.
+. Use `curl` to execute a `GET` request against the `{value-name-app}-greeting` service. You can also use the `Invoke` button in the web interface to do this.
 // include image of the invoke button?
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.{osl-route-hostname}/api/greeting
+$ curl http://{value-name-app}-greeting-{value-name-project}.{value-route-osl-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 +
 // Add note about the Toggle button not working
 // no scaler implemented error if CLI used to scale down pod
 +
-. To simulate the failure of the `{app-name}-name` service you can:
+. To simulate the failure of the `{value-name-app}-name` service you can:
 +
 * use the `Toggle` button in the web interface.
-* scale the number of replicas of the pod running the `{app-name}-name` service down to 0.
-* execute an HTTP `PUT` request against the `/api/state` endpoint of the `{app-name}-name` service to set its state to `fail`.
+* scale the number of replicas of the pod running the `{value-name-app}-name` service down to 0.
+* execute an HTTP `PUT` request against the `/api/state` endpoint of the `{value-name-app}-name` service to set its state to `fail`.
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{app-name}-name-{project-name}.{osl-route-hostname}/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://{value-name-app}-name-{value-name-project}.{value-route-osl-hostname}/api/state
 ----
 +
 . Invoke the `/api/greeting` endpoint. When several requests on the `/api/name` endpoint fail:
@@ -80,20 +80,20 @@ $ curl -X PUT -H "Content-Type: application/json" -d '{"state": "fail"}' http://
 +
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.{osl-route-hostname}/api/greeting
+$ curl http://{value-name-app}-greeting-{value-name-project}.{value-route-osl-hostname}/api/greeting
 {"content":"Hello, Fallback!"}
 ----
 +
-. Restore the name `{app-name}-name` service to availability.
+. Restore the name `{value-name-app}-name` service to availability.
 To do this you can:
 +
 * use the `Toggle` button in the web interface.
-* scale the number of replicas of the pod running the `{app-name}-name` service back up to 1.
-* execute an HTTP `PUT` request against the `/api/state` endpoint of the `{app-name}-name` service to set its state back to `ok`.
+* scale the number of replicas of the pod running the `{value-name-app}-name` service back up to 1.
+* execute an HTTP `PUT` request against the `/api/state` endpoint of the `{value-name-app}-name` service to set its state back to `ok`.
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{app-name}-name-{project-name}.{osl-route-hostname}/api/state
+$ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{value-name-app}-name-{value-name-project}.{value-route-osl-hostname}/api/state
 ----
 +
 . Invoke the `/api/greeting` endpoint again. When several requests on the `/api/name` endpoint succeed:
@@ -103,6 +103,6 @@ $ curl -X PUT -H "Content-Type: application/json" -d '{"state": "ok"}' http://{a
 +
 [source,bash,options="nowrap",subs="attributes"]
 ----
-$ curl http://{app-name}-greeting-{project-name}.{osl-route-hostname}/api/greeting
+$ curl http://{value-name-app}-greeting-{value-name-project}.{value-route-osl-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----

--- a/docs/topics/proc_interacting-with-the-crud-api-on-node.adoc
+++ b/docs/topics/proc_interacting-with-the-crud-api-on-node.adoc
@@ -15,13 +15,13 @@ When you have finished creating your application booster, you can interact with 
 --
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route {app-name}
+$ oc get route {value-name-app}
 ----
 
 [source,option="nowrap",subs="attributes+"]
 ----
 NAME                 HOST/PORT                                         PATH      SERVICES             PORT      TERMINATION
-{app-name}           {app-name}-{project-name}.{os-route-hostname}              {app-name}           8080
+{value-name-app}           {value-name-app}-{value-name-project}.{value-route-openshift-hostname}              {value-name-app}           8080
 ----
 --
 
@@ -30,7 +30,7 @@ NAME                 HOST/PORT                                         PATH     
 --
 [source,bash,subs="attributes+"]
 ----
-http://{app-name}-{project-name}.{os-route-hostname}
+http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}
 ----
 
 Alternatively, you can make requests directly on the `api/fruits/*` endpoint using `curl`:
@@ -38,7 +38,7 @@ Alternatively, you can make requests directly on the `api/fruits/*` endpoint usi
 .List all entries in the database:
 [source,bash,subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits
 ----
 
 [source,json,subs="attributes+"]
@@ -61,7 +61,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
 .Retrieve an entry with a specific ID
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/3
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/3
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -76,7 +76,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/3
 .Create a new entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1}'  http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
+$ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1}'  http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -91,7 +91,7 @@ $ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1
 .Update an Entry
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":100}'  http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/1
+$ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":100}'  http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/1
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -106,7 +106,7 @@ $ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":10
 .Delete an Entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -X DELETE http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/1
+$ curl -X DELETE http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/1
 ----
 --
 

--- a/docs/topics/proc_interacting-with-the-crud-api.adoc
+++ b/docs/topics/proc_interacting-with-the-crud-api.adoc
@@ -15,13 +15,13 @@ When you have finished creating your application booster, you can interact with 
 --
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route {app-name}
+$ oc get route {value-name-app}
 ----
 
 [source,option="nowrap",subs="attributes+"]
 ----
 NAME                 HOST/PORT                                         PATH      SERVICES             PORT      TERMINATION
-{app-name}           {app-name}-{project-name}.{os-route-hostname}              {app-name}           8080
+{value-name-app}           {value-name-app}-{value-name-project}.{value-route-openshift-hostname}              {value-name-app}           8080
 ----
 --
 
@@ -30,7 +30,7 @@ NAME                 HOST/PORT                                         PATH     
 --
 [source,bash,subs="attributes+"]
 ----
-http://{app-name}-{project-name}.{os-route-hostname}
+http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}
 ----
 
 Alternatively, you can make requests directly on the `api/fruits/*` endpoint using `curl`:
@@ -38,7 +38,7 @@ Alternatively, you can make requests directly on the `api/fruits/*` endpoint usi
 .List all entries in the database:
 [source,bash,subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits
 ----
 
 [source,json,subs="attributes+"]
@@ -61,7 +61,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
 .Retrieve an entry with a specific ID
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/3
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/3
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -76,7 +76,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/3
 .Create a new entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1}'  http://{app-name}-{project-name}.{os-route-hostname}/api/fruits
+$ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1}'  http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -91,7 +91,7 @@ $ curl -H "Content-Type: application/json" -X POST -d '{"name":"Peach","stock":1
 .Update an Entry
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":"100"}'  http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/1
+$ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":"100"}'  http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/1
 ----
 
 [source,json,options="nowrap",subs="attributes+"]
@@ -106,7 +106,7 @@ $ curl -H "Content-Type: application/json" -X PUT -d '{"name":"Apple","stock":"1
 .Delete an Entry:
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl -X DELETE http://{app-name}-{project-name}.{os-route-hostname}/api/fruits/1
+$ curl -X DELETE http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/fruits/1
 ----
 --
 

--- a/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-node.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-node.adoc
@@ -15,7 +15,7 @@ You can also use a browser to do this.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello, World from a ConfigMap !"}
 ----
 
@@ -35,7 +35,7 @@ You can also do this from your browser using the web form provided by the applic
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Bonjour, World from a ConfigMap !"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-springboot.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-springboot.adoc
@@ -15,7 +15,7 @@ You can also use a browser to do this.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 ----
 
@@ -32,7 +32,7 @@ Change the value for the `greeting.message` key to `Bonjour!` and save the file.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc rollout latest dc/{app-name}
+$ oc rollout latest dc/{value-name-app}
 ----
 
 . Check the status of your booster and ensure your new pod is running.
@@ -41,11 +41,11 @@ $ oc rollout latest dc/{app-name}
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa       1/1       Running     0          58s
-{app-name}-s2i-1-build   0/1       Completed   0          2m
+{value-name-app}-1-aaaaa       1/1       Running     0          58s
+{value-name-app}-s2i-1-build   0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once it's fully deployed and started.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once it's fully deployed and started.
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -55,7 +55,7 @@ You can also do this from your browser using the web form provided by the applic
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Bonjour!"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-vertx.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-vertx.adoc
@@ -15,7 +15,7 @@ You can also use a browser to do this.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello, World from a ConfigMap !"}
 ----
 . Update the deployed ConfigMap configuration.
@@ -35,7 +35,7 @@ You can also do this from your browser using the web form provided by the applic
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Bonjour, World from a ConfigMap !"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-wildflyswarm.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-configmap-booster-for-wildflyswarm.adoc
@@ -14,7 +14,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 ----
 
@@ -32,7 +32,7 @@ After you save this, the changes will be propagated to your OpenShift instance.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc rollout latest dc/{app-name}
+$ oc rollout latest dc/{value-name-app}
 ----
 
 . Check the status of your booster and ensure your new pod is running.
@@ -41,11 +41,11 @@ $ oc rollout latest dc/{app-name}
 ----
 $ oc get pods -w
 NAME                             READY     STATUS      RESTARTS   AGE
-{app-name}-1-aaaaa       1/1       Running     0          58s
-{app-name}-s2i-1-build   0/1       Completed   0          2m
+{value-name-app}-1-aaaaa       1/1       Running     0          58s
+{value-name-app}-s2i-1-build   0/1       Completed   0          2m
 ----
 +
-The `{app-name}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
+The `{value-name-app}-1-aaaaa` pod should have a status of `Running` once its fully deployed and started.
 Your specific pod name will vary.
 The number in the middle will increase with each new build.
 The letters at the end are generated when the pod is created.
@@ -55,7 +55,7 @@ You can also do this from your browser using the web form provided by the applic
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Bonjour World from a ConfigMap!"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-health-check-booster.adoc
@@ -1,7 +1,7 @@
 [id='interacting-with-the-unmodified-health-check-booster_{context}']
 = Interacting with the unmodified {name-mission-health-check} booster
 
-Once you have the booster deployed, you will have a service called `{app-name}` running that exposes the following REST endpoints:
+Once you have the booster deployed, you will have a service called `{value-name-app}` running that exposes the following REST endpoints:
 
 /api/greeting::
 ifdef::built-for-vertx,built-for-nodejs[Returns a JSON containing greeting of `name` parameter (or World as default value).]
@@ -15,13 +15,13 @@ This failure of an available service causes the OpenShift self-healing capabilit
 
 Alternatively, you can use the web interface to perform these steps.
 
-. Use `curl` to execute a `GET` request against the `{app-name}` service.
+. Use `curl` to execute a `GET` request against the `{value-name-app}` service.
 You can also use a browser to do this.
 +
 --
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 ----
 
 [source,options="nowrap",subs="attributes+"]
@@ -40,7 +40,7 @@ ifdef::built-for-spring-boot[an `Application is not available` page.]
 
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/stop
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/stop
 ----
 
 ifdef::built-for-vertx,built-for-nodejs[]
@@ -54,7 +54,7 @@ endif::[]
 
 [source,bash,option="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 ----
 
 // Responses vary wildly among runtimes
@@ -110,8 +110,8 @@ In addition to that, the `RESTARTS` count increases every time you you invoke th
 ----
 $ oc get pods -w
 NAME                           READY     STATUS    RESTARTS   AGE
-{app-name}-1-26iy7   0/1       Running   5          18m
-{app-name}-1-26iy7   1/1       Running   5         19m
+{value-name-app}-1-26iy7   0/1       Running   5          18m
+{value-name-app}-1-26iy7   1/1       Running   5         19m
 ----
 --
 
@@ -122,7 +122,7 @@ Alternatively to the interaction using the terminal window, you can use the web 
 
 [source,option="nowrap",subs="attributes+"]
 ----
-http://{app-name}-{project-name}.{os-route-hostname}
+http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}
 ----
 --
 

--- a/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-node.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-node.adoc
@@ -14,7 +14,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -22,7 +22,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting?name=Sarah
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-springboot.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-springboot.adoc
@@ -14,7 +14,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -22,7 +22,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting?name=Sarah
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-vertx.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-vertx.adoc
@@ -14,7 +14,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {
   "content" : "Hello, World!"
 }
@@ -24,7 +24,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting?name=Sarah
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting?name=Sarah
 {
   "content" : "Hello, Sarah!"
 }

--- a/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-wildflyswarm.adoc
+++ b/docs/topics/proc_interacting-with-the-unmodified-http-api-booster-for-wildflyswarm.adoc
@@ -14,7 +14,7 @@ The booster provides a default HTTP endpoint that accepts GET requests.
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting
 {"content":"Hello, World!"}
 ----
 
@@ -22,7 +22,7 @@ $ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://{app-name}-{project-name}.{os-route-hostname}/api/greeting?name=Sarah
+$ curl http://{value-name-app}-{value-name-project}.{value-route-openshift-hostname}/api/greeting?name=Sarah
 {"content":"Hello, Sarah!"}
 ----
 

--- a/docs/topics/proc_merging-contributions.adoc
+++ b/docs/topics/proc_merging-contributions.adoc
@@ -8,12 +8,12 @@ IMPORTANT: Do not merge your own pull requests unless absolutely necessary. You 
 
 .Prerequisites
 
-* GitHub account with merge access to the _{repo-docs-name}_ repository and GPG configured.
+* GitHub account with merge access to the _{name-repo-docs}_ repository and GPG configured.
 
 .Procedure
 
 .Merging a Pull Request
-. Ensure that you have the contributor's fork of the _{repo-docs-name}_ repository in your list of remotes:
+. Ensure that you have the contributor's fork of the _{name-repo-docs}_ repository in your list of remotes:
 +
 [source,bash,options="nowrap"]
 ----
@@ -29,7 +29,7 @@ $ git remote -v
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ git remote add username git@github.com:username/{repo-docs-name}.git
+$ git remote add username git@github.com:username/{name-repo-docs}.git
 ----
 .. Use `git remote -v` to verify that the fork is now listed among your remotes.
 .. Execute `git remote update` to fetch the latest state of the remotes to your working directory.

--- a/docs/topics/proc_releasing-launcher-docs.adoc
+++ b/docs/topics/proc_releasing-launcher-docs.adoc
@@ -1,6 +1,6 @@
 
 [id='releasing-launcher-docs_{context}']
-= Releasing {docs-name} docs
+= Releasing {name-docs} docs
 
 This section contains all information you need to release a new version of the documentation set to production. This update can happen anytime after the catalog has been updated, including after the release train has been completed.
 
@@ -39,7 +39,7 @@ Replace `$REMOTE` with the name of the upstream remote.
 --
 
 . Request publication:
-.. File a pull request in the link:https://github.com/openshiftio/saas-launchpad/blob/master/launchpad-services/launcher-documentation.yaml#L2[openshiftio/saas-launchpad] repository, where you change the `hash` value to the hash of the commit you want to publish from the link:{link-repo-docs}[{repo-docs-name}] repository. Usually, this will be the latest commit in the `master` branch.
+.. File a pull request in the link:https://github.com/openshiftio/saas-launchpad/blob/master/launchpad-services/launcher-documentation.yaml#L2[openshiftio/saas-launchpad] repository, where you change the `hash` value to the hash of the commit you want to publish from the link:{link-repo-docs}[{name-repo-docs}] repository. Usually, this will be the latest commit in the `master` branch.
 .. Wait for the pull request to be accepted. When that happens, verify that the link:{link-docs}[production build] succeeded.
 .. Once your changes have been merged and the build succeeds, delete the topic branch you used to introduce the update.
 +

--- a/docs/topics/proc_starting-and-configuring-the-openshiftlocal-for-the-launcher-tool.adoc
+++ b/docs/topics/proc_starting-and-configuring-the-openshiftlocal-for-the-launcher-tool.adoc
@@ -1,7 +1,7 @@
 [id='starting-and-configuring-the-openshiftlocal-for-the-launcher-tool_{context}']
-= Starting and configuring the {OpenShiftLocal} for the {launcher} tool
+= Starting and configuring the {OpenShiftLocal} for the {name-launcher} tool
 
-This chapter contains instructions for starting the {OpenShiftLocal} and configuring it to execute the {launcher} tool.
+This chapter contains instructions for starting the {OpenShiftLocal} and configuring it to execute the {name-launcher} tool.
 
 NOTE: Starting your {OpenShiftLocal} can trigger a download of large virtual machines or Linux container images. This can take a long time. Subsequent startups are expected to be shorter as long as the virtual machines and Linux container images remain cached.
 

--- a/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
@@ -1,16 +1,16 @@
 // This is a parameterized module. Parameters used:
 //
 //  context: used in anchor IDs to conflicts due to duplicate IDs.
-//  env-var-name: Name of environment variable
-//  env-var-val: value of environment variable
-//  port: debugging port on OpenShift
+//  parameter-env-var-name: Name of environment variable
+//  parameter-env-var-val: value of environment variable
+//  parameter-port: debugging port on OpenShift
 //
 // Rationale: This procedure is the same for 2 or more runtimes.
 
 [id='starting-your-application-on-openshift-in-debugging-mode_{context}']
 = Starting your application on OpenShift in debugging mode
 
-To debug your {runtime}-based application on OpenShift remotely, you must set the `{env-var-name}` environment variable inside the container to `{env-var-val}` and configure port forwarding so that you can connect to your application from a remote debugger.
+To debug your {runtime}-based application on OpenShift remotely, you must set the `{parameter-env-var-name}` environment variable inside the container to `{parameter-env-var-value}` and configure port forwarding so that you can connect to your application from a remote debugger.
 
 .Prerequisites
 
@@ -27,17 +27,17 @@ To debug your {runtime}-based application on OpenShift remotely, you must set th
 $ oc get dc
 ----
 
-ifndef::nodejs[]
-. Set the `{env-var-name}` environment variable in the deployment configuration of your application to `{env-var-val}`, which configures the JVM to open the port number `{port}` for debugging. 
-endif::nodejs[]
-ifdef::nodejs[]
-. Set the `{env-var-name}` environment variable in the deployment configuration of your application to `{env-var-val}` to enable debugging.
-endif::nodejs[]
+ifndef::built-for-nodejs[]
+. Set the `{parameter-env-var-name}` environment variable in the deployment configuration of your application to `{parameter-env-var-value}`, which configures the JVM to open the port number `{parameter-port}` for debugging. 
+endif::built-for-nodejs[]
+ifdef::built-for-nodejs[]
+. Set the `{parameter-env-var-name}` environment variable in the deployment configuration of your application to `{parameter-env-var-value}` to enable debugging.
+endif::built-for-nodejs[]
 For example:
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc set env dc/{value-name-app} {env-var-name}={env-var-val}
+$ oc set env dc/{value-name-app} {parameter-env-var-name}={parameter-env-var-value}
 ----
 
 . Redeploy the application if it is not set to redeploy automatically on configuration change. For example:
@@ -63,14 +63,14 @@ NAME                            READY     STATUS      RESTARTS   AGE
 --
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc port-forward {value-name-app}-3-1xrsp $LOCAL_PORT_NUMBER:{port}
+$ oc port-forward {value-name-app}-3-1xrsp $LOCAL_PORT_NUMBER:{parameter-port}
 ----
 
 Here, `$LOCAL_PORT_NUMBER` is an unused port number of your choice on your local machine.
 Remember this number for the remote debugger configuration.
 --
 
-ifdef::nodejs[]
+ifdef::built-for-nodejs[]
 . Attach the V8 inspector and perform debugging commands. 
 +
 For example, if using Google Chrome:
@@ -81,17 +81,17 @@ For example, if using Google Chrome:
 .. Click _Done_.
 .. Select your application from below _Remote Target_.
 .. You can now see the source of your application and can perform debugging actions.
-endif::nodejs[]
+endif::built-for-nodejs[]
 
-. When you are done debugging, unset the `{env-var-name}` environment variable in your application pod. For example:
+. When you are done debugging, unset the `{parameter-env-var-name}` environment variable in your application pod. For example:
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc set env dc/{value-name-app} {env-var-name}-
+$ oc set env dc/{value-name-app} {parameter-env-var-name}-
 ----
 
-ifndef::nodejs[]
+ifndef::built-for-nodejs[]
 .Additional resources
 
-You can also set the `{env-var-name}_PORT` environment variable if you want to change the debug port from the default, which is `{port}`.
-endif::nodejs[]
+You can also set the `{parameter-env-var-name}_PORT` environment variable if you want to change the debug port from the default, which is `{parameter-port}`.
+endif::built-for-nodejs[]

--- a/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
+++ b/docs/topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc
@@ -37,14 +37,14 @@ For example:
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc set env dc/{app-name} {env-var-name}={env-var-val}
+$ oc set env dc/{value-name-app} {env-var-name}={env-var-val}
 ----
 
 . Redeploy the application if it is not set to redeploy automatically on configuration change. For example:
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc rollout latest dc/{app-name}
+$ oc rollout latest dc/{value-name-app}
 ----
 
 . Configure port forwarding from your local machine to the application pod:
@@ -54,7 +54,7 @@ $ oc rollout latest dc/{app-name}
 ----
 $ oc get pod
 NAME                            READY     STATUS      RESTARTS   AGE
-{app-name}-3-1xrsp          0/1       Running     0          6s
+{value-name-app}-3-1xrsp          0/1       Running     0          6s
 ...
 ----
 
@@ -63,7 +63,7 @@ NAME                            READY     STATUS      RESTARTS   AGE
 --
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc port-forward {app-name}-3-1xrsp $LOCAL_PORT_NUMBER:{port}
+$ oc port-forward {value-name-app}-3-1xrsp $LOCAL_PORT_NUMBER:{port}
 ----
 
 Here, `$LOCAL_PORT_NUMBER` is an unused port number of your choice on your local machine.
@@ -87,7 +87,7 @@ endif::nodejs[]
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc set env dc/{app-name} {env-var-name}-
+$ oc set env dc/{value-name-app} {env-var-name}-
 ----
 
 ifndef::nodejs[]

--- a/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
+++ b/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
@@ -59,7 +59,7 @@ It has not been tested for use with CDK.
 --
 [source,bash,subs="attributes+"]
 ----
-oc login https://{osl-login-url} -u developer -p developer
+oc login https://{value-url-osl-auth} -u developer -p developer
 ----
 
 You can reuse the Docker daemon instance used by {OpenShiftLocal} to download the latest versions of the Nexus Docker container image.
@@ -110,7 +110,7 @@ oc volumes dc/nexus --add --name 'nexus-volume-1' --type 'pvc' --mount-path '/so
 +
 [source,bash,subs="attributes+"]
 ----
-oc project {project-name}
+oc project {value-name-project}
 ----
 
 . Define and start a new build.
@@ -126,7 +126,7 @@ If it does not, see the Nexus documentation for instructions on link:https://hel
 
 [source,bash,subs="attributes+"]
 ----
-$ oc new-build {app-name}:latest~{scm-repo-url} \
+$ oc new-build {value-name-app}:latest~{scm-repo-url} \
 -e MAVEN_MIRROR_URL='http://nexus.{nexus-project-name}:8081/nexus/content/groups/public'
 ----
 
@@ -137,12 +137,12 @@ To access images provided by Red Hat, add the link:https://maven.repository.redh
 . Ensure that your new build is using Nexus to retrieve artifacts. Do one of the following:
 +
 --
-* Navigate to `\http://nexus-{nexus-project-name}.{osl-route-hostname}/nexus/content/groups/public` to view the list of artifacts stored in your local repository.
+* Navigate to `\http://nexus-{nexus-project-name}.{value-route-osl-hostname}/nexus/content/groups/public` to view the list of artifacts stored in your local repository.
 * Check the log output of the build:
 +
 [source,bash,subs="attributes+"]
 ----
-$ oc logs build/{app-name}-1 --follow
+$ oc logs build/{value-name-app}-1 --follow
 ----
 
 If your build uses Nexus to retrieve artifacts, the build log output should reference the path `\http://nexus.{nexus-project-name}:8081/`.

--- a/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
+++ b/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
@@ -13,7 +13,7 @@ This reduces the network load when building your application, and helps accelera
 .Prerequisites
 
 * Your {OpenShiftLocal} set up.
-Follow the instructions in link:{link-launcher-openshift-local-install-guide}[{minishift-installation-guide-name}].
+Follow the instructions in link:{link-launcher-openshift-local-install-guide}[{name-guide-minishift-installation}].
 
 ////
 * Set up your project for use with Maven.

--- a/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
+++ b/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
@@ -7,7 +7,7 @@
 = Using a Nexus repository server on a {OpenShiftLocal}
 
 While developing your cloud-native applications with Java and Maven, you may be required to build them repeatedly.
-You can deploy a Nexus Repository server alongside the {launcher} tool on your {OpenShiftLocal} and use it to fetch artifacts from the Maven Central repository and cache them locally.
+You can deploy a Nexus Repository server alongside the {name-launcher} tool on your {OpenShiftLocal} and use it to fetch artifacts from the Maven Central repository and cache them locally.
 This reduces the network load when building your application, and helps accelerate the build and rolling updates.
 
 .Prerequisites
@@ -47,7 +47,7 @@ It has not been tested for use with CDK.
 ====
 --
 
-* The {launcher} tool deployed to your {OpenShiftLocal}.
+* The {name-launcher} tool deployed to your {OpenShiftLocal}.
 
 * A booster application deployed to your {OpenShiftLocal}.
 

--- a/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
+++ b/docs/topics/proc_using-a-nexus-repository-server-on-a-openshiftlocal.adoc
@@ -13,7 +13,7 @@ This reduces the network load when building your application, and helps accelera
 .Prerequisites
 
 * Your {OpenShiftLocal} set up.
-Follow the instructions in link:{link-launcher-openshift-local-install-guide}[{name-guide-minishift-installation}].
+Follow the instructions in link:{link-guide-minishift-installation}[{name-guide-minishift-installation}].
 
 ////
 * Set up your project for use with Maven.

--- a/docs/topics/proc_using-hystrix-dashboard-to-monitor-the-circuit-breaker.adoc
+++ b/docs/topics/proc_using-hystrix-dashboard-to-monitor-the-circuit-breaker.adoc
@@ -13,7 +13,7 @@ Hystrix Dashboard lets you easily monitor the health of your services in real ti
 +
 [source,bash,subs="attributes+",options="nowrap"]
 ----
-$ oc login {link-oso-auth} --token=MYTOKEN
+$ oc login {value-url-oso-auth} --token=MYTOKEN
 ----
 
 . To access the Web console, use your browser to navigate to your {OpenShiftLocal} URL.
@@ -22,7 +22,7 @@ $ oc login {link-oso-auth} --token=MYTOKEN
 +
 [source,bash,subs="attributes+",options="nowrap"]
 ----
-$ oc project {project-name}
+$ oc project {value-name-project}
 ----
 
 . Import the link:https://raw.githubusercontent.com/snowdrop/openshift-templates/master/hystrix-dashboard/hystrix-dashboard.yml[YAML template] for the Hystrix Dashboard application.
@@ -50,25 +50,25 @@ $ oc new-app --template=hystrix-dashboard
 ----
 $ oc get route hystrix-dashboard
 NAME                HOST/PORT                                                    PATH      SERVICES            PORT      TERMINATION   WILDCARD
-hystrix-dashboard   hystrix-dashboard-{project-name}.{osl-route-hostname}                 hystrix-dashboard   <all>                   None
+hystrix-dashboard   hystrix-dashboard-{value-name-project}.{value-route-osl-hostname}                 hystrix-dashboard   <all>                   None
 ----
 
 . To access the Dashboard, open the Dashboard application route URL in your browser.
 Alternatively, you can navigate to the _Overview_ screen in the Web console and click the route URL in the header above the pod containing your Hystrix Dashboard application.
 
-. To use the Dashboard to monitor the `{app-name}-greeting` service, replace the default event stream address with the following address and click the _Monitor Stream_ button.
+. To use the Dashboard to monitor the `{value-name-app}-greeting` service, replace the default event stream address with the following address and click the _Monitor Stream_ button.
 +
 --
 ifdef::built-for-spring-boot[]
 [source,subs="attributes+",options="nowrap"]
 ----
-http://{app-name}-greeting-{project-name}.{osl-route-hostname}/hystrix.stream
+http://{value-name-app}-greeting-{value-name-project}.{value-route-osl-hostname}/hystrix.stream
 ----
 endif::[]
 ifndef::built-for-spring-boot[]
 [source,subs="attributes+",options="nowrap"]
 ----
-http://{app-name}-greeting/hystrix.stream
+http://{value-name-app}-greeting/hystrix.stream
 ----
 endif::[]
 --

--- a/docs/topics/proc_verifying-pull-requests.adoc
+++ b/docs/topics/proc_verifying-pull-requests.adoc
@@ -2,13 +2,13 @@
 [id='verifying-pull-requests_{context}']
 = Verifying pull requests
 
-Technical writers and members of the QE team must verify pull requests in the link:{link-repo-docs}[{repo-docs-name}^] repository before they are merged to ensure high quality of the documentation.
+Technical writers and members of the QE team must verify pull requests in the link:{link-repo-docs}[{name-repo-docs}^] repository before they are merged to ensure high quality of the documentation.
 Reviews from other stakeholders and the community are welcome.
 
 .Prerequisites
 
 * A GitHub account.
-* You account subscribed to the link:{link-repo-docs}[{repo-docs-name}^] repository.
+* You account subscribed to the link:{link-repo-docs}[{name-repo-docs}^] repository.
 +
 --
 To subscribe to the repository:

--- a/docs/topics/proc_viewing-the-booster-source-code-and-readme.adoc
+++ b/docs/topics/proc_viewing-the-booster-source-code-and-readme.adoc
@@ -5,16 +5,16 @@
 
 One of the following:
 
-* Access to {launcher-oso}
-* {launcher} installed on a {OpenShiftLocal}
+* Access to {name-launcher-oso}
+* {name-launcher} installed on a {OpenShiftLocal}
 
 .Procedure
 
-. Use the {launcher} tool to generate your own version of the booster.
+. Use the {name-launcher} tool to generate your own version of the booster.
 . View the generated GitHub repository or download and extract the ZIP file that contains the booster source code.
 
 .Additional resources
 
-* link:{link-guide-getting-started}#deploying-a-booster-to-openshiftonline_getting-started[Using {launcher-oso}] 
-* link:{link-guide-getting-started}#creating-and-deploying-a-booster-using-your-openshiftlocal_getting-started[Using the {launcher} tool on a {OpenShiftLocal}]
+* link:{link-guide-getting-started}#deploying-a-booster-to-openshiftonline_getting-started[Using {name-launcher-oso}] 
+* link:{link-guide-getting-started}#creating-and-deploying-a-booster-using-your-openshiftlocal_getting-started[Using the {name-launcher} tool on a {OpenShiftLocal}]
 

--- a/docs/topics/proc_viewing-the-booster-source-code-and-readme.adoc
+++ b/docs/topics/proc_viewing-the-booster-source-code-and-readme.adoc
@@ -15,6 +15,6 @@ One of the following:
 
 .Additional resources
 
-* link:{link-getting-started-guide}#deploying-a-booster-to-openshiftonline_getting-started[Using {launcher-oso}] 
-* link:{link-getting-started-guide}#creating-and-deploying-a-booster-using-your-openshiftlocal_getting-started[Using the {launcher} tool on a {OpenShiftLocal}]
+* link:{link-guide-getting-started}#deploying-a-booster-to-openshiftonline_getting-started[Using {launcher-oso}] 
+* link:{link-guide-getting-started}#creating-and-deploying-a-booster-using-your-openshiftlocal_getting-started[Using the {launcher} tool on a {OpenShiftLocal}]
 

--- a/docs/topics/readme/cache-README.adoc
+++ b/docs/topics/readme/cache-README.adoc
@@ -54,9 +54,9 @@ $ ${OSORunCMD}
 +
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route ${app-name} -o jsonpath={$.spec.host}
+$ oc get route ${value-name-app} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
+${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 . Navigate to the `greeting` service using your browser.

--- a/docs/topics/readme/configmap-README.adoc
+++ b/docs/topics/readme/configmap-README.adoc
@@ -69,19 +69,19 @@ To interact with your booster while it's running on a Single-node OpenShift Clus
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route ${app-name} -o jsonpath={$.spec.host}
+$ oc get route ${value-name-app} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
+${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 You can use the form at your application's url or you can use the `curl` command:
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
+$ curl http://${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello World from a ConfigMap!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
+$ curl http://${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
 {"content":"Hello Sarah from a ConfigMap!"}
 ----
 

--- a/docs/topics/readme/health-check-README.adoc
+++ b/docs/topics/readme/health-check-README.adoc
@@ -53,9 +53,9 @@ To interact with your booster while it's running on a Single-node OpenShift Clus
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ oc get route ${app-name} -o jsonpath={$.spec.host}
+$ oc get route ${value-name-app} -o jsonpath={$.spec.host}
 
-${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
+${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME
 ----
 
 
@@ -63,17 +63,17 @@ You can use the form at your application's url or you can use the `curl` command
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
+$ curl http://${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting
 {"content":"Hello World!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
+$ curl http://${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/greeting?name=Sarah
 {"content":"Hello Sarah!"}
 
-$ curl http://${app-name}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/stop
+$ curl http://${value-name-app}-MY_PROJECT_NAME.LOCAL_OPENSHIFT_HOSTNAME/api/stop
 
 $ oc get pods -w
 NAME                           READY     STATUS    RESTARTS   AGE
-${app-name}-1-26iy7   1/1       Running   5          18m
+${value-name-app}-1-26iy7   1/1       Running   5          18m
 ----
 
 When `READY` changes to `0/1`, if you re-execute a `curl` command to `api/greeting` or attempt to access the application's URL, it will be unavailable. When `READY` changes back to `1/1`, `curl` commands and the application URL will be available again.

--- a/docs/topics/readme/rest-http-secured-README.adoc
+++ b/docs/topics/readme/rest-http-secured-README.adoc
@@ -28,7 +28,7 @@ $ ${localRunCMD}
 
 == Interacting with the Booster on a Single-node OpenShift Cluster
 
-To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain the secured booster endpoint URL, which is the _${app-name}_ service:
+To interact with your booster while it's running on a Single-node OpenShift Cluster, you first need to obtain the secured booster endpoint URL, which is the _${value-name-app}_ service:
 
 [source,bash,options="nowrap",subs="attributes+"]
 ----
@@ -49,10 +49,10 @@ A sample output is shown in the following table:
 | <all>
 | passthrough
 
-| ${app-name}
-| ${app-name}-myproject.LOCAL_OPENSHIFT_HOSTNAME
+| ${value-name-app}
+| ${value-name-app}-myproject.LOCAL_OPENSHIFT_HOSTNAME
 |
-| secured-${app-name}-http
+| secured-${value-name-app}-http
 | <all>
 |
 
@@ -65,7 +65,7 @@ A sample output is shown in the following table:
 |===
 ====
 
-In the above example, the booster endpoint would be `\http://${app-name}-myproject.LOCAL_OPENSHIFT_HOSTNAME`.
+In the above example, the booster endpoint would be `\http://${value-name-app}-myproject.LOCAL_OPENSHIFT_HOSTNAME`.
 
 You can interact with the booster using the form at the secured endpoint URL and the link:${guideURL}#rhsso-realm-model_secured[provided users].
 

--- a/docs/topics/ref_additional-wildflyswarm-resources.adoc
+++ b/docs/topics/ref_additional-wildflyswarm-resources.adoc
@@ -1,7 +1,7 @@
 [id='additional-wildflyswarm-resources_{context}']
 = Additional {WildFlySwarm} resources
 
-* link:https://docs.wildfly-swarm.io/{WildFlySwarmVersion}/[{WildFlySwarm} Community Documentation]
+* link:https://docs.wildfly-swarm.io/{version-thorntail-community}/[{WildFlySwarm} Community Documentation]
 * link:https://github.com/wildfly-swarm/wildfly-swarm-presentations[{WildFlySwarm} Presentations]
 * link:https://github.com/redhat-Microservices/lab_swarm-openshift[{WildFlySwarm}, Microservices & OpenShift Lab]
 * link:https://access.redhat.com/documentation/en-us/reference_architectures/2017/html/wildfly_swarm_microservices_on_red_hat_openshift_container_platform_3/[{WildFlySwarm} Microservices On Red Hat OpenShift Container Platform 3]

--- a/docs/topics/ref_branches-and-tags.adoc
+++ b/docs/topics/ref_branches-and-tags.adoc
@@ -2,7 +2,7 @@
 
 = Branches and tags
 
-The following branches and tags are used in the _{repo-docs-name}_ repository:
+The following branches and tags are used in the _{name-repo-docs}_ repository:
 
 .Branch Names and Contents
 [options="header",cols="1,3"]

--- a/docs/topics/ref_breakdown-of-vertx-pom-components.adoc
+++ b/docs/topics/ref_breakdown-of-vertx-pom-components.adoc
@@ -146,7 +146,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>{Fabric8MavenPluginVersion}</version>
+            <version>{version-fabric8-maven-plugin}</version>
             <executions>
               <execution>
                 <id>fmp</id>

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -8,7 +8,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-miss
 
 ifndef::built-for-vertx[* link:{link-mission-cache-vertx}[{name-mission-cache} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} mission - {WildFlySwarm} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-cache-thorntail}[{name-mission-cache} mission - {WildFlySwarm} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-cache-nodejs}[{name-mission-cache} mission - {Node} booster]]
 

--- a/docs/topics/ref_caching-resources.adoc
+++ b/docs/topics/ref_caching-resources.adoc
@@ -4,11 +4,11 @@
 
 More background and related information on caching can be found here:
 
-ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-mission-cache} Mission - {SpringBoot} Booster]]
+ifndef::built-for-spring-boot[* link:{link-mission-cache-spring-boot}[{name-mission-cache} mission - {SpringBoot} booster]]
 
-ifndef::built-for-vertx[* link:{link-mission-cache-vertx}[{name-mission-cache} Mission - {VertX} Booster]]
+ifndef::built-for-vertx[* link:{link-mission-cache-vertx}[{name-mission-cache} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} Mission - {WildFlySwarm} Booster]]
+ifndef::built-for-thorntail[* link:{link-mission-cache-wf-swarm}[{name-mission-cache} mission - {WildFlySwarm} booster]]
 
-ifndef::built-for-nodejs[* link:{link-mission-cache-nodejs}[{name-mission-cache} Mission - {Node} Booster]]
+ifndef::built-for-nodejs[* link:{link-mission-cache-nodejs}[{name-mission-cache} mission - {Node} booster]]
 

--- a/docs/topics/ref_circuit-breaker-resources.adoc
+++ b/docs/topics/ref_circuit-breaker-resources.adoc
@@ -7,18 +7,11 @@ Follow the links below for more background information on the design principles 
 
 * link:https://martinfowler.com/bliki/CircuitBreaker.html[Martin Fowler: CircuitBreaker]
 
-ifndef::built-for-spring-boot[]
-* link:{link-mission-circuit-breaker-spring-boot}[{mission-circuit-breaker-spring-boot-guide-name}]
-endif::built-for-spring-boot[]
+ifndef::built-for-spring-boot[* link:{link-mission-circuit-breaker-spring-boot}[{name-mission-circuit-breaker} mission - {SpringBoot} booster]]
 
-ifndef::built-for-vertx[]
-* link:{link-mission-circuit-breaker-vertx}[{mission-circuit-breaker-vertx-guide-name}]
-endif::built-for-vertx[]
+ifndef::built-for-vertx[* link:{link-mission-circuit-breaker-vertx}[{name-mission-circuit-breaker} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[]
-* link:{link-mission-circuit-breaker-wf-swarm}[{mission-circuit-breaker-wf-swarm-guide-name}]
-endif::built-for-thorntail[]
+ifndef::built-for-nodejs[* link:{link-mission-circuit-breaker-nodejs}[{name-mission-circuit-breaker} mission - {Node} booster]]
 
-ifndef::built-for-nodejs[]
-* link:{link-mission-circuit-breaker-nodejs}[{mission-circuit-breaker-nodejs-guide-name}]
-endif::built-for-nodejs[]
+ifndef::built-for-thorntail[* link:{link-mission-circuit-breaker-nodejs}[{name-mission-circuit-breaker} mission - {Thorntail} booster]]
+

--- a/docs/topics/ref_community-and-product-versions-of-vertx.adoc
+++ b/docs/topics/ref_community-and-product-versions-of-vertx.adoc
@@ -3,7 +3,7 @@
 
 .Supported {Vertx} Version
 
-{Vertx} components version `{VertXVersion}` are supported and provided as part of a Red Hat subscription.
+{Vertx} components version `{version-vertx}` are supported and provided as part of a Red Hat subscription.
 Supported {Vertx} runtime artifacts are available in the link:https://maven.repository.redhat.com/ga/[Red Hat Middleware JBoss General Availability Maven Repository^].
 
 .Technology Preview {Vertx} Components

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -17,7 +17,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[{name-
 
 ifndef::built-for-vertx[* link:{link-mission-configmap-vertx}[{name-mission-configmap} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-configmap-wf-swarm}[{name-mission-configmap} mission - {WildFlySwarm} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-configmap-thorntail}[{name-mission-configmap} mission - {WildFlySwarm} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[{name-mission-configmap} mission - {Node} booster]]
 

--- a/docs/topics/ref_configmap-resources.adoc
+++ b/docs/topics/ref_configmap-resources.adoc
@@ -4,13 +4,20 @@
 More background and related information on {name-mission-configmap} and ConfigMap can be found here:
 
 * link:https://docs.openshift.org/latest/dev_guide/configmaps.html[OpenShift ConfigMap Documentation]
+
 * link:https://blog.openshift.com/configuring-your-application-part-1/[Blog Post about ConfigMap in OpenShift]
 
 ifdef::built-for-spring-boot[* link:http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config[Externalized Configuration with {SpringBoot}]]
+
 ifdef::built-for-vertx[* link:http://vertx.io/docs/vertx-config/js/[Externalized Configuration with {VertX}]]
+
 ifdef::built-for-thorntail[* link:https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/content/v/eee1f5ba4dd4f13855cbe98addd365ba29033810/configuration/index.html[Externalized Configuration with {WildFlySwarm}]]
-ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[Externalized Configuration - {SpringBoot} Booster]]
-ifndef::built-for-vertx[* link:{link-mission-configmap-vertx}[Externalized Configuration - {VertX} Booster]]
-ifndef::built-for-thorntail[* link:{link-mission-configmap-wf-swarm}[Externalized Configuration - {WildFlySwarm} Booster]]
-ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[Externalized Configuration - {Node} Booster]]
+
+ifndef::built-for-spring-boot[* link:{link-mission-configmap-spring-boot}[{name-mission-configmap} mission - {SpringBoot} booster]]
+
+ifndef::built-for-vertx[* link:{link-mission-configmap-vertx}[{name-mission-configmap} mission - {VertX} booster]]
+
+ifndef::built-for-thorntail[* link:{link-mission-configmap-wf-swarm}[{name-mission-configmap} mission - {WildFlySwarm} booster]]
+
+ifndef::built-for-nodejs[* link:{link-mission-configmap-nodejs}[{name-mission-configmap} mission - {Node} booster]]
 

--- a/docs/topics/ref_glossary.adoc
+++ b/docs/topics/ref_glossary.adoc
@@ -4,14 +4,14 @@
 
 == Product and project names
 
-{launcher-oso}:: link:{link-launcher-oso}[{launcher-oso}] is a standalone getting started experience offered by Red Hat for jumpstarting cloud-native application development on OpenShift. It provides a hassle-free way of creating functional example applications, called missions, as well as an easy way to build and deploy those missions to OpenShift. 
+{name-launcher-oso}:: link:{link-launcher-oso}[{name-launcher-oso}] is a standalone getting started experience offered by Red Hat for jumpstarting cloud-native application development on OpenShift. It provides a hassle-free way of creating functional example applications, called missions, as well as an easy way to build and deploy those missions to OpenShift. 
 
-{launcher}:: The {launcher} is the upstream project on which link:{link-launcher-oso}[{launcher-oso}] is based.
+{name-launcher}:: The {name-launcher} is the upstream project on which link:{link-launcher-oso}[{name-launcher-oso}] is based.
 
 {OpenShiftLocal}:: An OpenShift cluster running on your machine using Minishift.
 
 
-== Terms specific to {launcher}
+== Terms specific to {name-launcher}
 
 [[glossary_booster]]
 Booster:: A language-specific implementation of a particular xref:glossary_mission[mission] on a particular xref:glossary_runtime[runtime]. Boosters are listed in a xref:glossary_booster_catalog[booster catalog].

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -15,7 +15,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-health-check-spring-boot}[{na
 
 ifndef::built-for-vertx[* link:{link-mission-health-check-vertx}[{name-mission-health-check} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-health-check-wf-swarm}[{name-mission-health-check} mission - {WildFlySwarm} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-health-check-thorntail}[{name-mission-health-check} mission - {WildFlySwarm} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-health-check-nodejs}[{name-mission-health-check} mission - {Node} booster]]
 

--- a/docs/topics/ref_health-check-resources.adoc
+++ b/docs/topics/ref_health-check-resources.adoc
@@ -4,22 +4,18 @@
 More background and related information on health checking can be found here:
 
 * link:https://docs.openshift.com/container-platform/latest/dev_guide/application_health.html[Overview of Application Health in OpenShift]
+
 * link:https://kubernetes.io/docs/user-guide/walkthrough/k8s201/#health-checking[Health Checking in Kubernetes]
+
 * link:https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/[Kubernetes Liveness and Readiness Probes]
+
 * link:https://kubernetes.io/docs/api-reference/v1/definitions/#_v1_probe[Kubernetes Probes]
 
-ifndef::built-for-spring-boot[]
-* link:{link-mission-health-check-spring-boot}[Health Check - {SpringBoot} Booster]
-endif::built-for-spring-boot[]
+ifndef::built-for-spring-boot[* link:{link-mission-health-check-spring-boot}[{name-mission-health-check} mission - {SpringBoot} booster]]
 
-ifndef::built-for-vertx[]
-* link:{link-mission-health-check-vertx}[Health Check - {VertX} Booster]
-endif::built-for-vertx[]
+ifndef::built-for-vertx[* link:{link-mission-health-check-vertx}[{name-mission-health-check} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[]
-* link:{link-mission-health-check-wf-swarm}[Health Check - {WildFlySwarm} Booster]
-endif::built-for-thorntail[]
+ifndef::built-for-thorntail[* link:{link-mission-health-check-wf-swarm}[{name-mission-health-check} mission - {WildFlySwarm} booster]]
 
-ifndef::built-for-nodejs[]
-  * link:{link-mission-health-check-nodejs}[Health Check - {Node} Booster]
-endif::built-for-nodejs[]
+ifndef::built-for-nodejs[* link:{link-mission-health-check-nodejs}[{name-mission-health-check} mission - {Node} booster]]
+

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -5,10 +5,13 @@
 More background and related information on running relational databases in OpenShift, CRUD, HTTP API and REST can be found here:
 
 * link:https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html[HTTP Verbs]
-* link:https://www.ics.uci.edu/~fielding/pubs/dissertation/fielding_dissertation.pdf[Architectural Styles and
-the Design of Network-based Software Architectures - Representational State Transfer (REST)]
+
+* link:https://www.ics.uci.edu/~fielding/pubs/dissertation/fielding_dissertation.pdf[Architectural Styles and the Design of Network-based Software Architectures - Representational State Transfer (REST)]
+
 * link:https://speakerdeck.com/glaforge/the-never-ending-rest-api-design-debate[The never ending REST API design debase]
+
 * link:http://roy.gbiv.com/untangled/2008/rest-apis-must-be-hypertext-driven[REST APIs must be Hypertext driven]
+
 * link:https://martinfowler.com/articles/richardsonMaturityModel.html[Richardson Maturity Model]
 
 ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
@@ -24,11 +27,11 @@ endif::built-for-vertx[]
 
 ifdef::built-for-thorntail[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
 
-ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{mission-crud-spring-boot-guide-name}]]
+ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{name-mission-crud} mission - {SpringBoot} booster]]
 
-ifndef::built-for-vertx[* link:{link-mission-crud-vertx}[{mission-crud-vertx-guide-name}]]
+ifndef::built-for-vertx[* link:{link-mission-crud-vertx}[{name-mission-crud} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-crud-wf-swarm}[{mission-crud-wf-swarm-guide-name}]]
+ifndef::built-for-thorntail[* link:{link-mission-crud-wf-swarm}[{name-mission-crud} mission - {Thorntail} booster]]
 
-ifndef::built-for-nodejs[* link:{link-mission-crud-nodejs}[{mission-crud-nodejs-guide-name}]]
+ifndef::built-for-nodejs[* link:{link-mission-crud-nodejs}[{name-mission-crud} mission - {Node} booster]]
 

--- a/docs/topics/ref_relational-database-resources.adoc
+++ b/docs/topics/ref_relational-database-resources.adoc
@@ -31,7 +31,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-crud-spring-boot}[{name-missi
 
 ifndef::built-for-vertx[* link:{link-mission-crud-vertx}[{name-mission-crud} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-crud-wf-swarm}[{name-mission-crud} mission - {Thorntail} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-crud-thorntail}[{name-mission-crud} mission - {Thorntail} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-crud-nodejs}[{name-mission-crud} mission - {Node} booster]]
 

--- a/docs/topics/ref_repository-location.adoc
+++ b/docs/topics/ref_repository-location.adoc
@@ -2,7 +2,7 @@
 
 = Repository location
 
-The repository for the mission and booster documentation, the Launchpad front page, and this contributor guide is hosted on GitHub in the link:{link-repo-docs}[{repo-docs-name}] repository.
+The repository for the mission and booster documentation, the Launchpad front page, and this contributor guide is hosted on GitHub in the link:{link-repo-docs}[{name-repo-docs}] repository.
 
 The runtime documentation repositories are hosted on the following locations:
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -22,7 +22,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{name-m
 
 ifndef::built-for-vertx[* link:{link-mission-http-api-vertx}[{name-mission-http-api} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-http-api-wf-swarm}[{name-mission-http-api} mission - {Thorntail} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-http-api-thorntail}[{name-mission-http-api} mission - {Thorntail} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{name-mission-http-api} mission - {Node} booster]]
 

--- a/docs/topics/ref_rest-resources.adoc
+++ b/docs/topics/ref_rest-resources.adoc
@@ -5,15 +5,24 @@ More background and related information on REST can be found here:
 
 * link:https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm[Architectural Styles and
 the Design of Network-based Software Architectures - Representational State Transfer (REST)]
+
 * link:https://martinfowler.com/articles/richardsonMaturityModel.html[Richardson Maturity Model]
 
 ifndef::built-for-nodejs[* link:https://www.jcp.org/en/jsr/detail?id=311[JSR 311: JAX-RS: The JavaTM API for RESTful Web Services]]
+
 ifdef::built-for-nodejs[* link:https://expressjs.com/[Express Web Framework]]
+
 ifdef::built-for-spring-boot[* link:https://spring.io/guides/gs/rest-service/[Building a RESTful Service with Spring]]
+
 ifdef::built-for-vertx[* link:http://vertx.io/blog/some-rest-with-vert-x/[Some Rest with {VertX}]]
+
 ifdef::built-for-thorntail[* link:http://resteasy.jboss.org/docs.html[RESTEasy Documentation]]
-ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{mission-http-api-spring-boot-guide-name}]]
-ifndef::built-for-vertx[* link:{link-mission-http-api-vertx}[{mission-http-api-vertx-guide-name}]]
-ifndef::built-for-thorntail[* link:{link-mission-http-api-wf-swarm}[{mission-http-api-wf-swarm-guide-name}]]
-ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{mission-http-api-nodejs-guide-name}]]
+
+ifndef::built-for-spring-boot[* link:{link-mission-http-api-spring-boot}[{name-mission-http-api} mission - {SpringBoot} booster]]
+
+ifndef::built-for-vertx[* link:{link-mission-http-api-vertx}[{name-mission-http-api} mission - {VertX} booster]]
+
+ifndef::built-for-thorntail[* link:{link-mission-http-api-wf-swarm}[{name-mission-http-api} mission - {Thorntail} booster]]
+
+ifndef::built-for-nodejs[* link:{link-mission-http-api-nodejs}[{name-mission-http-api} mission - {Node} booster]]
 

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -14,7 +14,7 @@ ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{name-mi
 
 ifndef::built-for-vertx[* link:{link-mission-secured-vertx}[{name-mission-secured} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-secured-wf-swarm}[{name-mission-secured} mission - {Thorntail} booster]]
+ifndef::built-for-thorntail[* link:{link-mission-secured-thorntail}[{name-mission-secured} mission - {Thorntail} booster]]
 
 ifndef::built-for-nodejs[* link:{link-mission-secured-nodejs}[{name-mission-secured} mission - {Node} booster]]
 

--- a/docs/topics/ref_secured-sso-resources.adoc
+++ b/docs/topics/ref_secured-sso-resources.adoc
@@ -10,11 +10,11 @@ Follow the links below for additional information on the principles behind the O
 
 * link:http://www.keycloak.org/archive/documentation-3.2.html[Keycloak 3.2 Documentation]
 
-ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{mission-secured-spring-boot-guide-name}]]
+ifndef::built-for-spring-boot[* link:{link-mission-secured-spring-boot}[{name-mission-secured} mission - {SpringBoot} booster]]
 
-ifndef::built-for-vertx[* link:{link-mission-secured-vertx}[{mission-secured-vertx-guide-name}]]
+ifndef::built-for-vertx[* link:{link-mission-secured-vertx}[{name-mission-secured} mission - {VertX} booster]]
 
-ifndef::built-for-thorntail[* link:{link-mission-secured-wf-swarm}[{mission-secured-wf-swarm-guide-name}]]
+ifndef::built-for-thorntail[* link:{link-mission-secured-wf-swarm}[{name-mission-secured} mission - {Thorntail} booster]]
 
-ifndef::built-for-nodejs[* link:{link-mission-secured-nodejs}[{mission-secured-nodejs-guide-name}]]
+ifndef::built-for-nodejs[* link:{link-mission-secured-nodejs}[{name-mission-secured} mission - {Node} booster]]
 

--- a/docs/topics/ref_springboot-tested-and-verified-version.adoc
+++ b/docs/topics/ref_springboot-tested-and-verified-version.adoc
@@ -5,6 +5,6 @@
 
 //.{SpringBoot} Tested and Verified Version
 
-The {SpringBoot} runtime version {SpringBootVersion} is tested and verified to run with the Embedded Apache Tomcat Container on OpenShift. When used with {SpringBoot}, this embedded container, as well as other components such as the Java container image, are part of a Red Hat subscription.
+The {SpringBoot} runtime version {version-spring-boot} is tested and verified to run with the Embedded Apache Tomcat Container on OpenShift. When used with {SpringBoot}, this embedded container, as well as other components such as the Java container image, are part of a Red Hat subscription.
 
 For a complete list of {SpringBoot} components provided as part of this release, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/index#rn-runtime-components-spring-boot[Release Notes].

--- a/docs/topics/ref_vertx-components-available-as-a-technology-preview.adoc
+++ b/docs/topics/ref_vertx-components-available-as-a-technology-preview.adoc
@@ -6,15 +6,15 @@ Red Hat provides link:https://access.redhat.com/support/offerings/techpreview/[l
 [options="header"]
 |===
 |GroupID | ArtifactID | Version
-|io.vertx | vertx-mongo | {VertXVersion}
-|io.vertx | vertx-mongo-service | {VertXVersion}
-|io.vertx | vertx-mongo-client | {VertXVersion}
-|io.vertx | vertx-rx | {VertXVersion}
-|io.vertx | vertx-rx-java | {VertXVersion}
-|io.vertx | vertx-sockjs-service-proxy | {VertXVersion}
-|io.vertx | vertx-redis-client | {VertXVersion}
-|io.vertx | vertx-infinispan | {VertXVersion}
-|io.vertx | vertx-proton | {VertXVersion}
-|io.vertx | vertx-grpc | {VertXVersion}
-|io.vertx | vertx-mqtt-server | {VertXVersion}
+|io.vertx | vertx-mongo | {version-vertx}
+|io.vertx | vertx-mongo-service | {version-vertx}
+|io.vertx | vertx-mongo-client | {version-vertx}
+|io.vertx | vertx-rx | {version-vertx}
+|io.vertx | vertx-rx-java | {version-vertx}
+|io.vertx | vertx-sockjs-service-proxy | {version-vertx}
+|io.vertx | vertx-redis-client | {version-vertx}
+|io.vertx | vertx-infinispan | {version-vertx}
+|io.vertx | vertx-proton | {version-vertx}
+|io.vertx | vertx-grpc | {version-vertx}
+|io.vertx | vertx-mqtt-server | {version-vertx}
 |===

--- a/docs/topics/resources/spring-boot/spring-boot-openshift-pom-config-example.xml
+++ b/docs/topics/resources/spring-boot/spring-boot-openshift-pom-config-example.xml
@@ -6,7 +6,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>{Fabric8MavenPluginVersion}</version>
+            <version>{version-fabric8-maven-plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/docs/topics/resources/spring-boot/spring-boot-starter-example-pom.xml
+++ b/docs/topics/resources/spring-boot/spring-boot-starter-example-pom.xml
@@ -19,7 +19,7 @@
       <dependency>
         <groupId>me.snowdrop</groupId>
         <artifactId>spring-boot-bom</artifactId>
-        <version>{SpringBootBOMVersion}</version>
+        <version>{version-spring-boot-bom}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>{SpringBootMvnPluginVersion}</version>
+        <version>{version-spring-boot-maven-plugin}</version>
       </plugin>
     </plugins>
   </build>
@@ -80,7 +80,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>{Fabric8MavenPluginVersion}</version>
+            <version>{version-fabric8-maven-plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/docs/topics/resources/vert-x/vertx-openshift-pom-config-example.xml
+++ b/docs/topics/resources/vert-x/vertx-openshift-pom-config-example.xml
@@ -6,7 +6,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>{Fabric8MavenPluginVersion}</version>
+            <version>{version-fabric8-maven-plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/docs/topics/resources/vert-x/vertx-starter-example-pom.xml
+++ b/docs/topics/resources/vert-x/vertx-starter-example-pom.xml
@@ -12,8 +12,8 @@
   <description>Example application using RHOAR Vert.x</description>
 
   <properties>
-    <vertx.version>{VertXVersion}</vertx.version>
-    <vertx-maven-plugin.version>{VertXMvnPluginVersion}</vertx-maven-plugin.version>
+    <vertx.version>{version-vertx}</vertx.version>
+    <vertx-maven-plugin.version>{version-vertx-maven-plugin}</vertx-maven-plugin.version>
     <vertx.verticle>com.example.MyApp</vertx.verticle>
     <fabric8.generator.from>registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.2</fabric8.generator.from>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -94,7 +94,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
-            <version>{Fabric8MavenPluginVersion}</version>
+            <version>{version-fabric8-maven-plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/docs/topics/templates/document-attributes-launcher.adoc
+++ b/docs/topics/templates/document-attributes-launcher.adoc
@@ -2,7 +2,7 @@
 :docinfodir: topics/styles
 :docinfo1:
 
-:ProductName: {OpenShiftAppDev}
+:ProductName: Application Development on OpenShift
 :ProductShortName: {ProductName}
 
 :imagesdir: images

--- a/docs/topics/templates/document-attributes-launcher.adoc
+++ b/docs/topics/templates/document-attributes-launcher.adoc
@@ -10,13 +10,12 @@
 :stylesdir: topics/styles
 :stylesheet: foundation.css
 
-:link-openshift-local-guide: /docs/minishift-installation.html
-:link-launcher-openshift-local-install-guide: /docs/minishift-installation.html
-:link-getting-started-guide: /docs/getting-started.html
-:link-spring-boot-runtime-guide: /docs/spring-boot-runtime.html
-:link-vertx-runtime-guide: /docs/vertx-runtime.html
-:link-wf-swarm-runtime-guide: /docs/thorntail-runtime.html
-:link-nodejs-runtime-guide: /docs/nodejs-runtime.html
+:link-guide-minishift-installation: /docs/minishift-installation.html
+:link-guide-getting-started: /docs/getting-started.html
+:link-guide-spring-boot: /docs/spring-boot-runtime.html
+:link-guide-vertx: /docs/vertx-runtime.html
+:link-guide-thorntail: /docs/thorntail-runtime.html
+:link-guide-nodejs: /docs/nodejs-runtime.html
 
 :link-launcher-yaml: /latest-launcher-template
 

--- a/docs/topics/templates/document-attributes-portal.adoc
+++ b/docs/topics/templates/document-attributes-portal.adoc
@@ -10,13 +10,12 @@
 
 :portal-base-url: https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/{DocInfoProductNumber}/html-single
 
-:link-launcher-openshift-local-install-guide: {portal-base-url}/install_and_configure_the_developers.redhat.comlaunch_application_on_a_single-node_openshift_cluster/
-:link-openshift-local-guide: {link-launcher-openshift-local-install-guide}
-:link-getting-started-guide: {portal-base-url}/getting_started_guide/
-:link-spring-boot-runtime-guide: {portal-base-url}/spring_boot_tomcat_runtime_guide/
-:link-vertx-runtime-guide: {portal-base-url}/eclipse_vert.x_runtime_guide/
-:link-wf-swarm-runtime-guide: {portal-base-url}/wildfly_swarm_runtime_guide/
-:link-nodejs-runtime-guide: {portal-base-url}/node.js_runtime_guide/
+:link-guide-minishift-installation: {portal-base-url}/install_and_configure_the_developers.redhat.comlaunch_application_on_a_single-node_openshift_cluster/
+:link-guide-getting-started: {portal-base-url}/getting_started_guide/
+:link-guide-spring-boot: {portal-base-url}/spring_boot_tomcat_runtime_guide/
+:link-guide-vertx: {portal-base-url}/eclipse_vert.x_runtime_guide/
+:link-guide-thorntail: {portal-base-url}/wildfly_swarm_runtime_guide/
+:link-guide-nodejs: {portal-base-url}/node.js_runtime_guide/
 
 :link-launcher-yaml: https://launcher.fabric8.io/latest-launcher-template
 

--- a/docs/topics/templates/document-attributes-portal.adoc
+++ b/docs/topics/templates/document-attributes-portal.adoc
@@ -9,7 +9,6 @@
 :DocInfoProductName: red-hat-openshift-application-runtimes
 
 :portal-base-url: https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/{DocInfoProductNumber}/html-single
-:link-launcher-yaml: https://launcher.fabric8.io/latest-launcher-template
 
 :link-launcher-openshift-local-install-guide: {portal-base-url}/install_and_configure_the_developers.redhat.comlaunch_application_on_a_single-node_openshift_cluster/
 :link-openshift-local-guide: {link-launcher-openshift-local-install-guide}

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -60,26 +60,22 @@ endif::[]
 :name-guide-thorntail: {WildFlySwarm} Runtime Guide
 :name-guide-nodejs: {Node} Runtime Guide
 
-// used in the BOM file example.
-:WildFlySwarmProductVersion: 2.2.0.Final-redhat-00021
-// also used in pom.xml examples for Spring Boot and Vertx
-:Fabric8MavenPluginVersion: 3.5.40
 
-// used in the links to additional upstream Swarm docs.
-:WildFlySwarmVersion: 2.2.0.Final
+// Versions
+:version-fabric8-maven-plugin: 3.5.40
 
-// spring boot version for rt guide
-:SpringBootVersion: 1.5.16.RELEASE
+:version-thorntail-product: 2.2.0.Final-redhat-00021
+:version-thorntail-community: 2.2.0.Final
 
-//used in BOM file example
-:SpringBootBOMVersion: 1.5.16.Final-redhat-00001
-:SpringBootMvnPluginVersion: 1.5.16.RELEASE
+:version-spring-boot: 1.5.16.RELEASE
+:version-spring-boot-bom: 1.5.16.Final-redhat-00001
+:version-spring-boot-maven-plugin: 1.5.16.RELEASE
 
-// used in the BOM file example and in the Vert.x Runtime developer Guide
-:VertXVersion: 3.5.4.redhat-00002
-:VertXMvnPluginVersion: 1.0.17
+:version-vertx: 3.5.4.redhat-00002
+:version-vertx-maven-plugin: 1.0.17
 
-:nodeshiftNodeVersion: --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8
+:version-node-nodeshift: --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8
+
 
 // POM file example variables
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -6,8 +6,8 @@ include::environment.adoc[]
 :icons: font
 :source-highlighter: highlightjs
 
-:launcher: Fabric8 Launcher
-:launcher-oso: developers.redhat.com/launch
+:name-launcher: Fabric8 Launcher
+:name-launcher-oso: developers.redhat.com/launch
 
 :OpenShiftOnline: OpenShift Online
 :OpenShiftLocal: Single-node OpenShift Cluster
@@ -48,7 +48,7 @@ endif::[]
 :name-mission-secured: Secured
 :name-mission-cache: Cache
 
-:name-guide-minishift-installation: Install and Configure the {launcher} Tool
+:name-guide-minishift-installation: Install and Configure the {name-launcher} Tool
 :name-guide-getting-started: Getting Started with {ProductName}
 :name-landing-page: Welcome
 :name-guide-contrib: Contribution Guide

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -147,10 +147,10 @@ endif::[]
 // Issue #489
 // externalize `github.com/appdev-documentation` repo references
 // changes NOT applicable to CHANGELOG and booster-specific README files.
-:repo-docs-name: launcher-documentation
+:name-repo-docs: launcher-documentation
 :link-repo-docs: https://github.com/fabric8-launcher/launcher-documentation
 
-:docs-name: launcher.fabric8.io
+:name-docs: launcher.fabric8.io
 :link-docs: https://launcher.fabric8.io
 
 // WildFly Swarm repository (mostly for the Contribution Guide)

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -77,40 +77,40 @@ endif::[]
 // POM file example variables
 
 // SPRING BOOT MISSIONS
-:link-mission-http-api-spring-boot: {link-spring-boot-runtime-guide}#mission-rest-http-spring-boot
-:link-mission-configmap-spring-boot: {link-spring-boot-runtime-guide}#mission-configmap-spring-boot
-:link-mission-crud-spring-boot: {link-spring-boot-runtime-guide}#mission-crud-spring-boot
-:link-mission-health-check-spring-boot: {link-spring-boot-runtime-guide}#mission-health-check-spring-boot
-:link-mission-secured-spring-boot: {link-spring-boot-runtime-guide}#mission-rest-http-secured-spring-boot
-:link-mission-circuit-breaker-spring-boot: {link-spring-boot-runtime-guide}#mission-circuit-breaker-spring-boot
-:link-mission-cache-spring-boot: {link-spring-boot-runtime-guide}#mission-cache-spring-boot
+:link-mission-http-api-spring-boot: {link-guide-spring-boot}#mission-rest-http-spring-boot
+:link-mission-configmap-spring-boot: {link-guide-spring-boot}#mission-configmap-spring-boot
+:link-mission-crud-spring-boot: {link-guide-spring-boot}#mission-crud-spring-boot
+:link-mission-health-check-spring-boot: {link-guide-spring-boot}#mission-health-check-spring-boot
+:link-mission-secured-spring-boot: {link-guide-spring-boot}#mission-rest-http-secured-spring-boot
+:link-mission-circuit-breaker-spring-boot: {link-guide-spring-boot}#mission-circuit-breaker-spring-boot
+:link-mission-cache-spring-boot: {link-guide-spring-boot}#mission-cache-spring-boot
 
 // VERT.X MISSIONS
-:link-mission-http-api-vertx: {link-vertx-runtime-guide}#mission-rest-http-vertx
-:link-mission-configmap-vertx: {link-vertx-runtime-guide}#mission-configmap-vertx
-:link-mission-crud-vertx: {link-vertx-runtime-guide}#mission-crud-vertx
-:link-mission-health-check-vertx: {link-vertx-runtime-guide}#mission-health-check-vertx
-:link-mission-secured-vertx: {link-vertx-runtime-guide}#mission-rest-http-secured-vertx
-:link-mission-circuit-breaker-vertx: {link-vertx-runtime-guide}#mission-circuit-breaker-vertx
-:link-mission-cache-vertx: {link-vertx-runtime-guide}#mission-cache-vertx
+:link-mission-http-api-vertx: {link-guide-vertx}#mission-rest-http-vertx
+:link-mission-configmap-vertx: {link-guide-vertx}#mission-configmap-vertx
+:link-mission-crud-vertx: {link-guide-vertx}#mission-crud-vertx
+:link-mission-health-check-vertx: {link-guide-vertx}#mission-health-check-vertx
+:link-mission-secured-vertx: {link-guide-vertx}#mission-rest-http-secured-vertx
+:link-mission-circuit-breaker-vertx: {link-guide-vertx}#mission-circuit-breaker-vertx
+:link-mission-cache-vertx: {link-guide-vertx}#mission-cache-vertx
 
 // THORNTAIL MISSIONS
-:link-mission-http-api-wf-swarm: {link-wf-swarm-runtime-guide}#mission-rest-http-wf-swarm
-:link-mission-configmap-wf-swarm: {link-wf-swarm-runtime-guide}#mission-configmap-wf-swarm
-:link-mission-crud-wf-swarm: {link-wf-swarm-runtime-guide}#mission-crud-wf-swarm
-:link-mission-health-check-wf-swarm: {link-wf-swarm-runtime-guide}#mission-health-check-wf-swarm
-:link-mission-secured-wf-swarm: {link-wf-swarm-runtime-guide}#mission-rest-http-secured-wf-swarm
-:link-mission-circuit-breaker-wf-swarm: {link-wf-swarm-runtime-guide}#mission-circuit-breaker-wf-swarm
-:link-mission-cache-wf-swarm: {link-wf-swarm-runtime-guide}#mission-cache-wf-swarm
+:link-mission-http-api-wf-swarm: {link-guide-thorntail}#mission-rest-http-wf-swarm
+:link-mission-configmap-wf-swarm: {link-guide-thorntail}#mission-configmap-wf-swarm
+:link-mission-crud-wf-swarm: {link-guide-thorntail}#mission-crud-wf-swarm
+:link-mission-health-check-wf-swarm: {link-guide-thorntail}#mission-health-check-wf-swarm
+:link-mission-secured-wf-swarm: {link-guide-thorntail}#mission-rest-http-secured-wf-swarm
+:link-mission-circuit-breaker-wf-swarm: {link-guide-thorntail}#mission-circuit-breaker-wf-swarm
+:link-mission-cache-wf-swarm: {link-guide-thorntail}#mission-cache-wf-swarm
 
 // NODE.JS MISSIONS
-:link-mission-http-api-nodejs: {link-nodejs-runtime-guide}#mission-rest-http-nodejs
-:link-mission-configmap-nodejs: {link-nodejs-runtime-guide}#mission-configmap-nodejs
-:link-mission-health-check-nodejs: {link-nodejs-runtime-guide}#mission-health-check-nodejs
-:link-mission-crud-nodejs: {link-nodejs-runtime-guide}#mission-crud-nodejs
-:link-mission-circuit-breaker-nodejs: {link-nodejs-runtime-guide}#mission-circuit-breaker-nodejs
-:link-mission-secured-nodejs: {link-nodejs-runtime-guide}#mission-rest-http-secured-nodejs
-:link-mission-cache-nodejs: {link-nodejs-runtime-guide}#mission-cache-nodejs
+:link-mission-http-api-nodejs: {link-guide-nodejs}#mission-rest-http-nodejs
+:link-mission-configmap-nodejs: {link-guide-nodejs}#mission-configmap-nodejs
+:link-mission-health-check-nodejs: {link-guide-nodejs}#mission-health-check-nodejs
+:link-mission-crud-nodejs: {link-guide-nodejs}#mission-crud-nodejs
+:link-mission-circuit-breaker-nodejs: {link-guide-nodejs}#mission-circuit-breaker-nodejs
+:link-mission-secured-nodejs: {link-guide-nodejs}#mission-rest-http-secured-nodejs
+:link-mission-cache-nodejs: {link-guide-nodejs}#mission-cache-nodejs
 
 :link-rhsso: https://github.com/obsidian-toaster-quickstarts/redhat-sso
 :link-launcher-oso: https://developers.redhat.com/launch

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -1,14 +1,29 @@
 include::environment.adoc[]
 
+// Basic metadata
 :toc: left
 :toclevels: 3
 :numbered:
 :icons: font
 :source-highlighter: highlightjs
+:ndash: &#x2013;
+:revnumber: {localdate}
+:SegmentTrackerToken: ${LAUNCHPAD_TRACKER_SEGMENT_TOKEN}
 
-:name-launcher: Fabric8 Launcher
-:name-launcher-oso: developers.redhat.com/launch
 
+// Launcher-specific attribute definitions
+ifdef::launcher-docs-only[]
+include::document-attributes-launcher.adoc[]
+endif::[]
+
+
+// Portal-specific docs attribute definitions
+ifdef::portal-docs-only[]
+include::document-attributes-portal.adoc[]
+endif::[]
+
+
+// Products
 :OpenShiftOnline: OpenShift Online
 :OpenShiftLocal: Single-node OpenShift Cluster
 :Minishift: Minishift
@@ -20,25 +35,15 @@ include::environment.adoc[]
 :VertX: Eclipse Vert.x
 :Node: Node.js
 :RHSSO: Red Hat SSO
-// Needs to be set to either "WildFly" or "JBoss EAP"
 :WildFly: JBoss EAP
 :DevStudio: Red Hat Developer Studio
 
-// Launcher-specific attribute definitions
-ifdef::launcher-docs-only[]
-include::document-attributes-launcher.adoc[]
-endif::[]
 
-// Portal-specific docs attribute definitions
-ifdef::portal-docs-only[]
-include::document-attributes-portal.adoc[]
-endif::[]
+// Names
+:name-docs: launcher.fabric8.io
 
-
-:ndash: &#x2013;
-
-
-:revnumber: {localdate}
+:name-launcher: Fabric8 Launcher
+:name-launcher-oso: developers.redhat.com/launch
 
 :name-mission-http-api: REST API Level 0
 :name-mission-configmap: Externalized Configuration
@@ -57,6 +62,8 @@ endif::[]
 :name-guide-thorntail: {WildFlySwarm} Runtime Guide
 :name-guide-nodejs: {Node} Runtime Guide
 
+:name-repo-docs: launcher-documentation
+
 
 // Versions
 :version-fabric8-maven-plugin: 3.5.40
@@ -74,46 +81,56 @@ endif::[]
 :version-node-nodeshift: --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8
 
 
-// POM file example variables
+// Links
+:link-docs: https://launcher.fabric8.io
 
-// SPRING BOOT MISSIONS
-:link-mission-http-api-spring-boot: {link-guide-spring-boot}#mission-rest-http-spring-boot
-:link-mission-configmap-spring-boot: {link-guide-spring-boot}#mission-configmap-spring-boot
-:link-mission-crud-spring-boot: {link-guide-spring-boot}#mission-crud-spring-boot
-:link-mission-health-check-spring-boot: {link-guide-spring-boot}#mission-health-check-spring-boot
-:link-mission-secured-spring-boot: {link-guide-spring-boot}#mission-rest-http-secured-spring-boot
-:link-mission-circuit-breaker-spring-boot: {link-guide-spring-boot}#mission-circuit-breaker-spring-boot
+:link-launcher-oso: https://developers.redhat.com/launch
+
+:link-mission-cache-nodejs: {link-guide-nodejs}#mission-cache-nodejs
 :link-mission-cache-spring-boot: {link-guide-spring-boot}#mission-cache-spring-boot
-
-// VERT.X MISSIONS
-:link-mission-http-api-vertx: {link-guide-vertx}#mission-rest-http-vertx
-:link-mission-configmap-vertx: {link-guide-vertx}#mission-configmap-vertx
-:link-mission-crud-vertx: {link-guide-vertx}#mission-crud-vertx
-:link-mission-health-check-vertx: {link-guide-vertx}#mission-health-check-vertx
-:link-mission-secured-vertx: {link-guide-vertx}#mission-rest-http-secured-vertx
-:link-mission-circuit-breaker-vertx: {link-guide-vertx}#mission-circuit-breaker-vertx
+:link-mission-cache-wf-swarm: {link-guide-thorntail}#mission-cache-wf-swarm
 :link-mission-cache-vertx: {link-guide-vertx}#mission-cache-vertx
 
-// THORNTAIL MISSIONS
-:link-mission-http-api-wf-swarm: {link-guide-thorntail}#mission-rest-http-wf-swarm
-:link-mission-configmap-wf-swarm: {link-guide-thorntail}#mission-configmap-wf-swarm
-:link-mission-crud-wf-swarm: {link-guide-thorntail}#mission-crud-wf-swarm
-:link-mission-health-check-wf-swarm: {link-guide-thorntail}#mission-health-check-wf-swarm
-:link-mission-secured-wf-swarm: {link-guide-thorntail}#mission-rest-http-secured-wf-swarm
-:link-mission-circuit-breaker-wf-swarm: {link-guide-thorntail}#mission-circuit-breaker-wf-swarm
-:link-mission-cache-wf-swarm: {link-guide-thorntail}#mission-cache-wf-swarm
-
-// NODE.JS MISSIONS
-:link-mission-http-api-nodejs: {link-guide-nodejs}#mission-rest-http-nodejs
-:link-mission-configmap-nodejs: {link-guide-nodejs}#mission-configmap-nodejs
-:link-mission-health-check-nodejs: {link-guide-nodejs}#mission-health-check-nodejs
-:link-mission-crud-nodejs: {link-guide-nodejs}#mission-crud-nodejs
 :link-mission-circuit-breaker-nodejs: {link-guide-nodejs}#mission-circuit-breaker-nodejs
-:link-mission-secured-nodejs: {link-guide-nodejs}#mission-rest-http-secured-nodejs
-:link-mission-cache-nodejs: {link-guide-nodejs}#mission-cache-nodejs
+:link-mission-circuit-breaker-spring-boot: {link-guide-spring-boot}#mission-circuit-breaker-spring-boot
+:link-mission-circuit-breaker-wf-swarm: {link-guide-thorntail}#mission-circuit-breaker-wf-swarm
+:link-mission-circuit-breaker-vertx: {link-guide-vertx}#mission-circuit-breaker-vertx
 
-:link-rhsso: https://github.com/obsidian-toaster-quickstarts/redhat-sso
-:link-launcher-oso: https://developers.redhat.com/launch
+:link-mission-configmap-nodejs: {link-guide-nodejs}#mission-configmap-nodejs
+:link-mission-configmap-spring-boot: {link-guide-spring-boot}#mission-configmap-spring-boot
+:link-mission-configmap-wf-swarm: {link-guide-thorntail}#mission-configmap-wf-swarm
+:link-mission-configmap-vertx: {link-guide-vertx}#mission-configmap-vertx
+
+:link-mission-crud-nodejs: {link-guide-nodejs}#mission-crud-nodejs
+:link-mission-crud-spring-boot: {link-guide-spring-boot}#mission-crud-spring-boot
+:link-mission-crud-wf-swarm: {link-guide-thorntail}#mission-crud-wf-swarm
+:link-mission-crud-vertx: {link-guide-vertx}#mission-crud-vertx
+
+:link-mission-health-check-nodejs: {link-guide-nodejs}#mission-health-check-nodejs
+:link-mission-health-check-spring-boot: {link-guide-spring-boot}#mission-health-check-spring-boot
+:link-mission-health-check-wf-swarm: {link-guide-thorntail}#mission-health-check-wf-swarm
+:link-mission-health-check-vertx: {link-guide-vertx}#mission-health-check-vertx
+
+:link-mission-http-api-nodejs: {link-guide-nodejs}#mission-rest-http-nodejs
+:link-mission-http-api-spring-boot: {link-guide-spring-boot}#mission-rest-http-spring-boot
+:link-mission-http-api-wf-swarm: {link-guide-thorntail}#mission-rest-http-wf-swarm
+:link-mission-http-api-vertx: {link-guide-vertx}#mission-rest-http-vertx
+
+:link-mission-secured-nodejs: {link-guide-nodejs}#mission-rest-http-secured-nodejs
+:link-mission-secured-spring-boot: {link-guide-spring-boot}#mission-rest-http-secured-spring-boot
+:link-mission-secured-wf-swarm: {link-guide-thorntail}#mission-rest-http-secured-wf-swarm
+:link-mission-secured-vertx: {link-guide-vertx}#mission-rest-http-secured-vertx
+
+:link-repo-docs: https://github.com/fabric8-launcher/launcher-documentation
+:link-repo-wildfly-swarm: https://github.com/thorntail/thorntail/
+
+:link-s2i-process: https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#source-build
+
+
+// Mission Knowledge Proficiency
+:proficiency-foundational: Foundational
+:proficiency-advanced: Advanced
+:proficiency-expert: Expert
 
 
 // Example values
@@ -130,27 +147,4 @@ endif::[]
 :red-hat-ga-repo-id: redhat-ga
 :red-hat-ga-repo-name: Red Hat GA Repository
 :red-hat-ga-repo-url: https://maven.repository.redhat.com/ga/
-
-
-// Mission Knowledge Proficiency
-// Usage expects all of these to be capitalized
-:proficiency-foundational: Foundational
-:proficiency-advanced: Advanced
-:proficiency-expert: Expert
-:SegmentTrackerToken: ${LAUNCHPAD_TRACKER_SEGMENT_TOKEN}
-
-// Issue #489
-// externalize `github.com/appdev-documentation` repo references
-// changes NOT applicable to CHANGELOG and booster-specific README files.
-:name-repo-docs: launcher-documentation
-:link-repo-docs: https://github.com/fabric8-launcher/launcher-documentation
-
-:name-docs: launcher.fabric8.io
-:link-docs: https://launcher.fabric8.io
-
-// WildFly Swarm repository (mostly for the Contribution Guide)
-:link-repo-wildfly-swarm: https://github.com/thorntail/thorntail/
-
-// Link S2I process (primarily for guides mission interaction sections)
-:link-s2i-process: https://docs.openshift.com/container-platform/latest/architecture/core_concepts/builds_and_image_streams.html#source-build
 

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -51,14 +51,14 @@ endif::[]
 :name-mission-secured: Secured
 :name-mission-cache: Cache
 
-:minishift-installation-guide-name: Install and Configure the {launcher} Tool
-:getting-started-guide-name: Getting Started with {ProductName}
-:landing-page-name: Welcome
-:contrib-guide-name: Contribution Guide
-:spring-boot-runtime-guide-name: {SpringBoot} Runtime Guide
-:vertx-runtime-guide-name: {VertX} Runtime Guide
-:wf-swarm-runtime-guide-name: {WildFlySwarm} Runtime Guide
-:nodejs-runtime-guide-name: {Node} Runtime Guide
+:name-guide-minishift-installation: Install and Configure the {launcher} Tool
+:name-guide-getting-started: Getting Started with {ProductName}
+:name-landing-page: Welcome
+:name-guide-contrib: Contribution Guide
+:name-guide-spring-boot: {SpringBoot} Runtime Guide
+:name-guide-vertx: {VertX} Runtime Guide
+:name-guide-thorntail: {WildFlySwarm} Runtime Guide
+:name-guide-nodejs: {Node} Runtime Guide
 
 // used in the BOM file example.
 :WildFlySwarmProductVersion: 2.2.0.Final-redhat-00021

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -38,8 +38,6 @@ endif::[]
 :ndash: &#x2013;
 
 
-:app-name: MY_APP_NAME
-:project-name: MY_PROJECT_NAME
 :revnumber: {localdate}
 
 :name-mission-http-api: REST API Level 0
@@ -78,10 +76,6 @@ endif::[]
 
 // POM file example variables
 
-:red-hat-ga-repo-id: redhat-ga
-:red-hat-ga-repo-name: Red Hat GA Repository
-:red-hat-ga-repo-url: https://maven.repository.redhat.com/ga/
-
 // SPRING BOOT MISSIONS
 :link-mission-http-api-spring-boot: {link-spring-boot-runtime-guide}#mission-rest-http-spring-boot
 :link-mission-configmap-spring-boot: {link-spring-boot-runtime-guide}#mission-configmap-spring-boot
@@ -118,23 +112,25 @@ endif::[]
 :link-mission-secured-nodejs: {link-nodejs-runtime-guide}#mission-rest-http-secured-nodejs
 :link-mission-cache-nodejs: {link-nodejs-runtime-guide}#mission-cache-nodejs
 
-
-:link-oso-auth: OPENSHIFT_URL
-:link-osl-auth: LOCAL_OPENSHIFT_URL
-
 :link-rhsso: https://github.com/obsidian-toaster-quickstarts/redhat-sso
 :link-launcher-oso: https://developers.redhat.com/launch
 
-// Minishift route URL e.g: 192.168.42.152.nip.io
-:osl-route-hostname: LOCAL_OPENSHIFT_HOSTNAME
 
-// Minishift access URL e.g: 192.168.42.152.:8443
-:osl-login-url: LOCAL_OPENSHIFT_URL:PORT
+// Example values
+:value-name-app: MY_APP_NAME
+:value-name-project: MY_PROJECT_NAME
 
-// OSO hostname e.g: 1ab5.starter-us-east-1.openshiftapps.com
-:oso-route-hostname: OPENSHIFT_ONLINE_HOSTNAME
+:value-url-osl-auth: LOCAL_OPENSHIFT_URL:PORT
+:value-url-oso-auth: OPENSHIFT_URL
 
-:os-route-hostname: OPENSHIFT_HOSTNAME
+:value-route-openshift-hostname: OPENSHIFT_HOSTNAME
+:value-route-osl-hostname: LOCAL_OPENSHIFT_HOSTNAME
+:value-route-oso-hostname: OPENSHIFT_ONLINE_HOSTNAME
+
+:red-hat-ga-repo-id: redhat-ga
+:red-hat-ga-repo-name: Red Hat GA Repository
+:red-hat-ga-repo-url: https://maven.repository.redhat.com/ga/
+
 
 // Mission Knowledge Proficiency
 // Usage expects all of these to be capitalized

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -8,7 +8,6 @@ include::environment.adoc[]
 
 :launcher: Fabric8 Launcher
 :launcher-oso: developers.redhat.com/launch
-:OpenShiftAppDev: Application Development on OpenShift
 
 :OpenShiftOnline: OpenShift Online
 :OpenShiftLocal: Single-node OpenShift Cluster

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -88,37 +88,37 @@ endif::[]
 
 :link-mission-cache-nodejs: {link-guide-nodejs}#mission-cache-nodejs
 :link-mission-cache-spring-boot: {link-guide-spring-boot}#mission-cache-spring-boot
-:link-mission-cache-wf-swarm: {link-guide-thorntail}#mission-cache-wf-swarm
+:link-mission-cache-thorntail: {link-guide-thorntail}#mission-cache-wf-swarm
 :link-mission-cache-vertx: {link-guide-vertx}#mission-cache-vertx
 
 :link-mission-circuit-breaker-nodejs: {link-guide-nodejs}#mission-circuit-breaker-nodejs
 :link-mission-circuit-breaker-spring-boot: {link-guide-spring-boot}#mission-circuit-breaker-spring-boot
-:link-mission-circuit-breaker-wf-swarm: {link-guide-thorntail}#mission-circuit-breaker-wf-swarm
+:link-mission-circuit-breaker-thorntail: {link-guide-thorntail}#mission-circuit-breaker-wf-swarm
 :link-mission-circuit-breaker-vertx: {link-guide-vertx}#mission-circuit-breaker-vertx
 
 :link-mission-configmap-nodejs: {link-guide-nodejs}#mission-configmap-nodejs
 :link-mission-configmap-spring-boot: {link-guide-spring-boot}#mission-configmap-spring-boot
-:link-mission-configmap-wf-swarm: {link-guide-thorntail}#mission-configmap-wf-swarm
+:link-mission-configmap-thorntail: {link-guide-thorntail}#mission-configmap-wf-swarm
 :link-mission-configmap-vertx: {link-guide-vertx}#mission-configmap-vertx
 
 :link-mission-crud-nodejs: {link-guide-nodejs}#mission-crud-nodejs
 :link-mission-crud-spring-boot: {link-guide-spring-boot}#mission-crud-spring-boot
-:link-mission-crud-wf-swarm: {link-guide-thorntail}#mission-crud-wf-swarm
+:link-mission-crud-thorntail: {link-guide-thorntail}#mission-crud-wf-swarm
 :link-mission-crud-vertx: {link-guide-vertx}#mission-crud-vertx
 
 :link-mission-health-check-nodejs: {link-guide-nodejs}#mission-health-check-nodejs
 :link-mission-health-check-spring-boot: {link-guide-spring-boot}#mission-health-check-spring-boot
-:link-mission-health-check-wf-swarm: {link-guide-thorntail}#mission-health-check-wf-swarm
+:link-mission-health-check-thorntail: {link-guide-thorntail}#mission-health-check-wf-swarm
 :link-mission-health-check-vertx: {link-guide-vertx}#mission-health-check-vertx
 
 :link-mission-http-api-nodejs: {link-guide-nodejs}#mission-rest-http-nodejs
 :link-mission-http-api-spring-boot: {link-guide-spring-boot}#mission-rest-http-spring-boot
-:link-mission-http-api-wf-swarm: {link-guide-thorntail}#mission-rest-http-wf-swarm
+:link-mission-http-api-thorntail: {link-guide-thorntail}#mission-rest-http-wf-swarm
 :link-mission-http-api-vertx: {link-guide-vertx}#mission-rest-http-vertx
 
 :link-mission-secured-nodejs: {link-guide-nodejs}#mission-rest-http-secured-nodejs
 :link-mission-secured-spring-boot: {link-guide-spring-boot}#mission-rest-http-secured-spring-boot
-:link-mission-secured-wf-swarm: {link-guide-thorntail}#mission-rest-http-secured-wf-swarm
+:link-mission-secured-thorntail: {link-guide-thorntail}#mission-rest-http-secured-wf-swarm
 :link-mission-secured-vertx: {link-guide-vertx}#mission-rest-http-secured-vertx
 
 :link-repo-docs: https://github.com/fabric8-launcher/launcher-documentation

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -51,35 +51,6 @@ endif::[]
 :name-mission-secured: Secured
 :name-mission-cache: Cache
 
-:mission-http-api-spring-boot-guide-name: {name-mission-http-api} Mission - {SpringBoot} Booster
-:mission-http-api-vertx-guide-name: {name-mission-http-api} Mission - {VertX} Booster
-:mission-http-api-wf-swarm-guide-name: {name-mission-http-api} Mission - {WildFlySwarm} Booster
-:mission-http-api-nodejs-guide-name: {name-mission-http-api} Mission - {Node} Booster
-:mission-configmap-spring-boot-guide-name: {name-mission-configmap} Mission - {SpringBoot} Booster
-:mission-configmap-vertx-guide-name: {name-mission-configmap} Mission - {VertX} Booster
-:mission-configmap-nodejs-guide-name: {name-mission-configmap} Mission - {Node} Booster
-:mission-configmap-wf-swarm-guide-name: {name-mission-configmap} Mission - {WildFlySwarm} Booster
-:mission-health-check-spring-boot-guide-name: {name-mission-health-check} Mission - {SpringBoot} Booster
-:mission-health-check-vertx-guide-name: {name-mission-health-check} Mission - {VertX} Booster
-:mission-health-check-wf-swarm-guide-name: {name-mission-health-check} Mission - {WildFlySwarm} Booster
-:mission-health-check-nodejs-guide-name: {name-mission-health-check} Mission - {Node} Booster
-:mission-circuit-breaker-spring-boot-guide-name: {name-mission-circuit-breaker} Mission - {SpringBoot} Booster
-:mission-circuit-breaker-vertx-guide-name: {name-mission-circuit-breaker} Mission - {VertX} Booster
-:mission-circuit-breaker-wf-swarm-guide-name: {name-mission-circuit-breaker} Mission - {WildFlySwarm} Booster
-:mission-circuit-breaker-nodejs-guide-name: {name-mission-circuit-breaker} Mission - {Node} Booster
-:mission-secured-spring-boot-guide-name: {name-mission-secured} Mission - {SpringBoot} Booster
-:mission-secured-vertx-guide-name: {name-mission-secured} Mission - {VertX} Booster
-:mission-secured-wf-swarm-guide-name: {name-mission-secured} Mission - {WildFlySwarm} Booster
-:mission-secured-nodejs-guide-name: {name-mission-secured} Mission - {Node} Booster
-:mission-crud-spring-boot-guide-name: {name-mission-crud} Mission - {SpringBoot} Booster
-:mission-crud-vertx-guide-name: {name-mission-crud} Mission - {VertX} Booster
-:mission-crud-wf-swarm-guide-name: {name-mission-crud} Mission - {WildFlySwarm} Booster
-:mission-crud-nodejs-guide-name: {name-mission-crud} Mission - {Node} Booster
-:mission-cache-spring-boot-guide-name: {name-mission-cache} Mission - {SpringBoot} Booster
-:mission-cache-vertx-guide-name: {name-mission-cache} Mission - {VertX} Booster
-:mission-cache-wf-swarm-guide-name: {name-mission-cache} Mission - {WildFlySwarm} Booster
-:mission-cache-nodejs-guide-name: {name-mission-cache} Mission - {Node} Booster
-
 :minishift-installation-guide-name: Install and Configure the {launcher} Tool
 :getting-started-guide-name: Getting Started with {ProductName}
 :landing-page-name: Welcome
@@ -115,16 +86,6 @@ endif::[]
 :red-hat-ga-repo-id: redhat-ga
 :red-hat-ga-repo-name: Red Hat GA Repository
 :red-hat-ga-repo-url: https://maven.repository.redhat.com/ga/
-
-:link-http-api-level-0-spring-boot-booster: https://github.com/snowdrop/rest_springboot
-:link-http-api-level-0-vertx-booster: https://github.com/openshiftio-vertx-boosters/vertx-http-booster
-:link-http-api-level-0-wf-swarm-booster: https://github.com/wildfly-swarm-openshiftio-boosters/rest-http
-:link-http-api-level-0-nodejs-booster: https://github.com/nodeshift-starters/nodejs-rest-http
-
-:link-configmap-spring-boot-booster: https://github.com/snowdrop/rest_configmap_springboot
-:link-configmap-vertx-booster: https://github.com/openshiftio-vertx-boosters/vertx-configmap-booster
-:link-configmap-nodejs-booster: https://github.com/nodeshift-starters/nodejs-configmap
-:link-configmap-wf-swarm-booster: https://github.com/wildfly-swarm-openshiftio-boosters/configmap
 
 // SPRING BOOT MISSIONS
 :link-mission-http-api-spring-boot: {link-spring-boot-runtime-guide}#mission-rest-http-spring-boot
@@ -195,10 +156,6 @@ endif::[]
 
 :docs-name: launcher.fabric8.io
 :link-docs: https://launcher.fabric8.io
-
-// stage environment URLs for Docs and Launcher
-:link-docs-stage: https://launcher-preview.fabric8.io/
-:link-launcher-stage: https://launch.prod-preview.openshift.io/
 
 // WildFly Swarm repository (mostly for the Contribution Guide)
 :link-repo-wildfly-swarm: https://github.com/thorntail/thorntail/

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -4,7 +4,7 @@ include::topics/templates/document-attributes.adoc[]
 :toclevels: 2
 :built-for-vertx:
 
-= {vertx-runtime-guide-name}
+= {name-guide-vertx}
 :runtime: {VertX}
 //var for front-end topics, if below is defined in topic, its used in docs, if not its used in the front end
 :docs-topic:

--- a/docs/vertx-runtime/master.adoc
+++ b/docs/vertx-runtime/master.adoc
@@ -124,10 +124,9 @@ include::topics/proc_starting-your-application-locally-in-debugging-mode.adoc[le
 //include::topics/proc_starting-an-uberjar-in-debugging-mode.adoc[leveloffset=+3]
 //:parameter-uberjar-documented!:
 
-:env-var-name: JAVA_DEBUG
-:env-var-val: true
-:port: 5005
-:nodejs!:
+:parameter-env-var-name: JAVA_DEBUG
+:parameter-env-var-value: true
+:parameter-port: 5005
 include::topics/proc_starting-your-application-on-openshift-in-debugging-mode.adoc[leveloffset=+3]
 
 include::topics/proc_attaching-a-remote-debugger-to-the-application.adoc[leveloffset=+3]


### PR DESCRIPTION
I have done the following things:

* Consolidated the naming that it follows a namespace-like policy:
  * `name-$SOMETHING` for names, like `name-guide-vertx` or `name-launcher`.
  * `link-$SOMETHING` for links, like `link-guide-vertx` or `link-launcher-oso`.
  * `version-$something` for version numbers, like `version-vertx` or `version-spring-boot-maven-plugin`.
  * `value-$SOMETHING` for example values, like `value-name-project` or `value-url-oso-auth`.
* Left `red-hat*` attributes as they are for now for compatibility reasons with the Thorntail repo.
* Left product names with the capitalised notation for the same reason.
* Verified there are minimal differences between the existing and new rendered docs. The only differences I have created are the link texts in the `-resources` files as they were sometimes inconsistent.

Due to the scope of the changes, I recommend reviewing individual commits.