### PR TITLE
RHOARDOC-1493: add pom.xml reference to MRRC for Spring Boot

### DIFF
--- a/docs/topics/proc_configuring-your-application-to-use-spring-boot.adoc
+++ b/docs/topics/proc_configuring-your-application-to-use-spring-boot.adoc
@@ -47,11 +47,11 @@ Include the following properties in your `pom.xml` file to track the version of 
 ----
 --
 
-. Specify the repositories containing {ProductShortName} {SpringBoot} Starters and the {SpringBoot} Maven Plugin.
+. Specify the repositories containing {ProductShortName} {SpringBoot} Starters and the {SpringBoot} Maven Plugin:
 
 [source,xml,subs="attributes+",options="nowrap"]
 ----
-<!-- Specify the repositories containing RHOAR artifacts. -->
+  <!-- Specify the repositories containing RHOAR artifacts. -->
   <repositories>
     <repository>
       <id>redhat-ga</id>

--- a/docs/topics/proc_configuring-your-application-to-use-spring-boot.adoc
+++ b/docs/topics/proc_configuring-your-application-to-use-spring-boot.adoc
@@ -34,7 +34,7 @@ Specify the `<type>pom</type>` and `<scope>import</scope>`:
 
 Include the following properties in your `pom.xml` file to track the version of {SpringBoot} and the {SpringBoot} Maven Plugin you are using:
 
-[source,xml,subs="attributes+"]
+[source,xml,subs="attributes+",options="nowrap"]
 ----
 <project>
   ...
@@ -46,6 +46,29 @@ Include the following properties in your `pom.xml` file to track the version of 
 </project>
 ----
 --
+
+. Specify the repositories containing {ProductShortName} {SpringBoot} Starters and the {SpringBoot} Maven Plugin.
+
+[source,xml,subs="attributes+",options="nowrap"]
+----
+<!-- Specify the repositories containing RHOAR artifacts. -->
+  <repositories>
+    <repository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </repository>
+  </repositories>
+
+  <!-- Specify the repositories containing the plugins used to execute the build of your application. -->
+  <pluginRepositories>
+    <pluginRepository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </pluginRepository>
+  </pluginRepositories>
+----
 
 . Reference `spring-boot-maven-plugin` as the plugin used to package your application:
 +


### PR DESCRIPTION
I added `pom.xml` references to the the basic project configuration example for Spring Boot.

The MRRC repo contains the productized starters.
The (non-productized) remainder of the Spring Boot 1.5.x dependency tree is distributed  using Maven Central. 