### PR TITLE
Add Java arguments to Vert.x applications deployed using FMP

### DIFF
--- a/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
@@ -33,5 +33,12 @@ endif::[]
 
 +
 In this profile, the Fabric8 Maven plugin is invoked for building and deploying the application to OpenShift.
-
+. Create a `deployment.yaml` file in the `src/main/fabric8` directory and add the `JAVA_OPTIONS` described in the example.
++
+ifdef::built-for-vertx[]
+[source,yaml,options="nowrap",subs="attributes+"]
+----
+include::resources/vert-x/vertx-fmp-deployment.yaml[]
+----
+endif::[]
 . Deploy the application to OpenShift according to instructions in xref:deploying-an-application-to-openshift_{context}[].

--- a/docs/topics/resources/vert-x/vertx-fmp-deployment.yaml
+++ b/docs/topics/resources/vert-x/vertx-fmp-deployment.yaml
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      containers:
+        - name: vertx
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: JAVA_OPTIONS
+              value: '-Dvertx.cacheDirBase=/tmp -Dvertx.jgroups.config=default'


### PR DESCRIPTION
Despite the misnamed branch, this resolves https://issues.jboss.org/browse/RHOARDOC-1439

@spisiakm @cescoffier 

Do we need to provide a rationale for why a developer should add these Java options for FMP deployments?