### PR TITLE
RHOARDOC-1475: New docs QE process

### DIFF
--- a/docs/topics/assembly_documentation-release-life-cycle.adoc
+++ b/docs/topics/assembly_documentation-release-life-cycle.adoc
@@ -12,6 +12,8 @@ include::proc_releasing-launcher-docs.adoc[leveloffset=+1]
 
 include::ref_releasing-customer-portal-docs.adoc[leveloffset=+1]
 
+include::con_documentation-publication-announcement.adoc[leveloffset=+1]
+
 include::proc_concluding-a-rhoardoc-jira-release.adoc[leveloffset=+1]
 
 

--- a/docs/topics/con_documentation-publication-announcement.adoc
+++ b/docs/topics/con_documentation-publication-announcement.adoc
@@ -1,0 +1,47 @@
+
+[id='documentation-publication-announcement_{context}']
+= Documentation publication announcement
+
+When the documentation is updated, send an e-mail containing a link to the new version and the diff from the live version to the following mailing lists:
+
+* obsidian-pm-list@redhat.com
+* obsidian-team-list@redhat.com
+* rhoar-docs-team@redhat.com
+* rhoar-qe-team@redhat.com
+
+Send the e-mail also to the following mailing lists if the publication concerns the respective runtime specifically:
+
+* Node.js: node-devel@redhat.com
+* Spring Boot: rh-spring-engineering@redhat.com
+* Thorntail: thorntail-internal@redhat.com
+* Vert.x: vertx-devel@redhat.com
+
+.Sample e-mail content
+====
+You can use the following template for the e-mail:
+
+WARNING: Replace the placeholders with real data before sending.
+
+----
+Hello,
+
+We have released the Fabric8 Launcher documentation today:
+
+Docs link: https://launcher.fabric8.io/docs/
+Tag: https://github.com/fabric8-launcher/launcher-documentation/releases/tag/$NEW_TAG
+Diff: https://github.com/fabric8-launcher/launcher-documentation/compare/$PREVIOUS_TAG...$NEW_TAG
+
+We have also synced the documentation to the Customer Portal stage:
+
+Docs link: https://access.redhat.com/documentation/red-hat-openshift-application-runtimes/
+Tag: $LINK_TO_THE_TAG
+Diff: $LINK_TO_THE_COMPARISON
+
+The following issues were fixed:
+
+https://issues.jboss.org/projects/RHOARDOC/versions/$RELEASE_ID
+
+Please reach out to rhoar-docs-team@redhat.com if you have any questions.
+----
+====
+

--- a/docs/topics/con_quality-control-requirements-for-documentation.adoc
+++ b/docs/topics/con_quality-control-requirements-for-documentation.adoc
@@ -8,5 +8,5 @@ To ensure good quality of the documentation, the following requirements must be 
 ** One member of the documentation team (different from the submitter).
 ** One member of either the engineering team or the QE team.
 
-* When a new version of the documentation is released to {name-docs}, a member of the QE team must review the diff between the live version and the new version.
+* When a new version of the documentation is pushed to the Customer Portal stage, a member of the QE team must review the diff between the live version and the new version.
 

--- a/docs/topics/proc_releasing-launcher-docs.adoc
+++ b/docs/topics/proc_releasing-launcher-docs.adoc
@@ -48,47 +48,8 @@ Replace `$REMOTE` with the name of the upstream remote.
 $ git branch -d $TOPIC_BRANCH_NAME
 --
 
-. Announce the publication:
-+
---
-Send an e-mail containing a link to the new version and the diff from the live version to the following mailing lists:
+.Next steps
 
-* obsidian-pm-list@redhat.com
-* obsidian-team-list@redhat.com
-* rhoar-docs-team@redhat.com
-* rhoar-qe-team@redhat.com
-
-Send the e-mail also to the following mailing lists if the publication concerns the respective runtime specifically:
-
-* Node.js: node-devel@redhat.com
-* Spring Boot: rh-spring-engineering@redhat.com
-* Thorntail: thorntail-internal@redhat.com
-* Vert.x: vertx-devel@redhat.com
-
-.Sample e-mail content
-====
-You can use the following template for the e-mail:
-
-WARNING: Replace the placeholders with real data before sending.
-
-----
-Hello,
-
-We have released the upstream documentation today.
-
-Docs link: https://launcher.fabric8.io/docs/
-Tag: https://github.com/fabric8-launcher/launcher-documentation/releases/tag/$NEW_TAG
-Diff: https://github.com/fabric8-launcher/launcher-documentation/compare/$PREVIOUS_TAG...$NEW_TAG
-
-The following issues were fixed:
-
-...
-
-We plan to do a downstream docs sync on $RELEASE_DATE.
-
-Please reach out to rhoar-docs-team@redhat.com if you have any questions.
-----
-====
-
---
+. Synchronize the sources to the Customer Portal stage.
+. Announce the publication.
 


### PR DESCRIPTION
RHOARDOC-1475

Notes:
* The items in the _Next steps_ section are intentionally not links because the related chapters follow immediately. Their usefulness is mostly in reminding the reader that the they must sync the docs and announce it.
* Appropriate changes will be filed in the downstream repository separately.