### PR TITLE
Fixed conditional in app deployment procedure

### DIFF
--- a/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
+++ b/docs/topics/proc_deploying-an-existing-application-to-openshift.adoc
@@ -33,9 +33,9 @@ endif::[]
 
 +
 In this profile, the Fabric8 Maven plugin is invoked for building and deploying the application to OpenShift.
+ifdef::built-for-vertx[]
 . Create a `deployment.yaml` file in the `src/main/fabric8` directory and add the `JAVA_OPTIONS` described in the example.
 +
-ifdef::built-for-vertx[]
 [source,yaml,options="nowrap",subs="attributes+"]
 ----
 include::resources/vert-x/vertx-fmp-deployment.yaml[]


### PR DESCRIPTION
Currently, the step describing the `deployment.yaml` file renders both in the Vert.x and Spring Boot guide. My understanding is, though, that the step is only valid for Vert.x. I believe this is just a case of a misplaced conditional.

@inoxx03, can you please ask someone from SB to verify this patch? Thanks.