### PR TITLE
RHOARDOC-1541: Added generic version to title of main SB runtime guide

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -57,7 +57,7 @@ endif::[]
 :name-guide-getting-started: Getting Started with {ProductName}
 :name-landing-page: Welcome
 :name-guide-contrib: Contribution Guide
-:name-guide-spring-boot: {SpringBoot} Runtime Guide
+:name-guide-spring-boot: {SpringBoot} 2.1.x Runtime Guide
 :name-guide-spring-boot-1-5: {SpringBoot} 1.5.x Runtime Guide
 :name-guide-vertx: {VertX} Runtime Guide
 :name-guide-thorntail: {WildFlySwarm} Runtime Guide


### PR DESCRIPTION
This PR partially resolves [RHOARDOC-1541](https://gitlab.cee.redhat.com/red-hat-openshift-application-runtimes-documentation/rhoar-release-notes/merge_requests/115).

This change doesn't really change much for the user experience in the Launcher docs, but having disparate link title and guide title on the Customer Portal is not great.