### PR TITLE
RHOARDOC: 1670 Removed modular content for example application assemblies

### DIFF
--- a/docs/topics/assembly_circuit-breaker-example-application.adoc
+++ b/docs/topics/assembly_circuit-breaker-example-application.adoc
@@ -9,11 +9,15 @@
 [id='example-circuit-breaker-{parameter-runtime-anchor}']
 = {name-example-circuit-breaker} example for {runtime}
 
-include::note-example-unavailable-oso.adoc[leveloffset=+1]
+Example proficiency level: 
+ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
+ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 
-include::circuit-breaker-example-intro-paragraph.adoc[leveloffset=+1]
+The _Circuit Breaker_ example demonstrates a generic pattern for reporting the failure of a service and then limiting access to the failed service until it becomes available to handle requests. This helps prevent cascading failure in other services that depend on the failed services for functionality.
 
 This example shows you how to implement a Circuit Breaker and Fallback pattern in your services.
+
+include::note-example-unavailable-oso.adoc[leveloffset=+1]
 
 include::con_the-circuit-breaker-design-pattern.adoc[leveloffset=+1]
 

--- a/docs/topics/assembly_configmap-example-application.adoc
+++ b/docs/topics/assembly_configmap-example-application.adoc
@@ -10,7 +10,13 @@
 [id='example-configmap-{parameter-runtime-anchor}']
 = {name-example-configmap} example for {runtime}
 
-include::configmap-example-intro-paragraph.adoc[leveloffset=+1]
+Example proficiency level:
+//special case since topic is used by front end.
+ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
+ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
+
+
+{name-example-configmap} provides a basic example of using a ConfigMap to externalize configuration. _ConfigMap_ is an object used by OpenShift to inject configuration data as simple key and value pairs into one or more Linux containers while keeping the containers independent of OpenShift.
 
 This example shows you how to:
 

--- a/docs/topics/assembly_configmap-example-application.adoc
+++ b/docs/topics/assembly_configmap-example-application.adoc
@@ -11,7 +11,6 @@
 = {name-example-configmap} example for {runtime}
 
 Example proficiency level:
-//special case since topic is used by front end.
 ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
 ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 

--- a/docs/topics/assembly_configmap-example-application.adoc
+++ b/docs/topics/assembly_configmap-example-application.adoc
@@ -15,7 +15,7 @@ ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
 ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 
 
-{name-example-configmap} provides a basic example of using a ConfigMap to externalize configuration. _ConfigMap_ is an object used by OpenShift to inject configuration data as simple key and value pairs into one or more Linux containers while keeping the containers independent of OpenShift.
+{name-example-configmap} provides a basic example of using a ConfigMap to externalize configuration. A ConfigMap is an object used by OpenShift to inject configuration data as simple key and value pairs into one or more Linux containers while keeping the containers independent of OpenShift.
 
 This example shows you how to:
 

--- a/docs/topics/assembly_crud-example-application.adoc
+++ b/docs/topics/assembly_crud-example-application.adoc
@@ -10,7 +10,6 @@
 = {name-example-crud} example for {runtime}
 
 Example proficiency level:
-//special case since topic is used by front end.
 ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
 ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 

--- a/docs/topics/assembly_crud-example-application.adoc
+++ b/docs/topics/assembly_crud-example-application.adoc
@@ -9,39 +9,16 @@
 [id='example-crud-{parameter-runtime-anchor}']
 = {name-example-crud} example for {runtime}
 
+Example proficiency level:
+//special case since topic is used by front end.
+ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
+ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
+
+The {name-example-crud} example expands on the {name-example-http-api} application to provide a basic example of performing _create_, _read_, _update_ and _delete_ (_CRUD_) operations on a PostgreSQL database using a simple HTTP API. _CRUD_ operations are the four basic functions of persistent storage, widely used when developing an HTTP API dealing with a database.
+
 include::note-example-unavailable-oso.adoc[leveloffset=+1]
 
-include::crud-example-intro-paragraph.adoc[leveloffset=+1]
-
-The example also demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift.
-Each runtime shows how to implement the connectivity solution best suited in the given case.
-The runtime can choose between options such as using _JDBC_, _JPA_, or accessing _ORM_ APIs directly.
-
-The example application exposes an HTTP API, which provides endpoints that allow you to manipulate data by performing  _CRUD_ operations over HTTP.
-The _CRUD_ operations are mapped to HTTP `Verbs`.
-The API uses JSON formatting to receive requests and return responses to the user.
-The user can also use a user interface provided by the example to use the application.
-Specifically, this example provides an application that allows you to:
-
-* Navigate to the application web interface in your browser.
-This exposes a simple website allowing you to perform _CRUD_ operations on the data in the `my_data` database.
-* Execute an HTTP `GET` request on the `api/fruits` endpoint.
-* Receive a response formatted as a JSON array containing the list of all fruits in the database.
-* Execute an HTTP `GET` request on the `api/fruits/*` endpoint while passing in a valid item ID as an argument.
-* Receive a response in JSON format containing the name of the fruit with the given ID.
-If no item matches the specified ID, the call results in an HTTP error 404.
-* Execute an HTTP `POST` request on the `api/fruits` endpoint passing in a valid `name` value to create a new entry in the database.
-* Execute an HTTP `PUT` request on the `api/fruits/*` endpoint passing in a valid ID and a name as an argument.
-This updates the name of the item with the given ID to match the name specified in your request.
-* Execute an HTTP `DELETE` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument.
-This removes the item with the specified ID from the database and returns an HTTP code `204` (No Content) as a response.
-If you pass in an invalid ID, the call results in an HTTP error `404`.
-
-ifndef::built-for-nodejs[]
-This example also contains a set of automated xref:running-the-example-application-integration-tests_{context}[integration tests] that can be used to verify that the application is fully integrated with the database.
-endif::built-for-nodejs[]
-
-This example does not showcase a fully matured RESTful model (level 3), but it does use compatible HTTP verbs and status, following the recommended HTTP API practices.
+include::con_purpose-of-the-relational-database-backend-pattern.adoc[leveloffset=+1]
 
 include::con_crud-design-tradeoffs.adoc[leveloffset=+1]
 

--- a/docs/topics/assembly_health-check-example-application.adoc
+++ b/docs/topics/assembly_health-check-example-application.adoc
@@ -10,7 +10,6 @@
 = {name-example-health-check} example for {runtime}
 
 Example proficiency level: 
-
 ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
 ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 

--- a/docs/topics/assembly_health-check-example-application.adoc
+++ b/docs/topics/assembly_health-check-example-application.adoc
@@ -9,20 +9,16 @@
 [id='example-health-check-{parameter-runtime-anchor}']
 = {name-example-health-check} example for {runtime}
 
-include::health-check-example-intro-paragraph.adoc[leveloffset=+1]
+Example proficiency level: 
+
+ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
+ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
+
+When you deploy an application, it is important to know if it is available and if it can start handling incoming requests. Implementing the _health check_ pattern allows you to monitor the health of an application, which includes if an application is available and whether it is able to service requests.
 
 NOTE: If you are not familiar with the health check terminology, see the xref:health-check-concepts_{context}[] section first.
 
-The purpose of this use case is to demonstrate the health check pattern through the use of probing.
-Probing is used to report the liveness and readiness of an application.
-In this use case, you configure an application which exposes an HTTP `health` endpoint to issue HTTP requests.
-If the container is alive, according to the liveness probe on the `health` HTTP endpoint, the management platform receives `200` as return code and no further action is required.
-If the `health` HTTP endpoint does not return a response, for example if the thread is blocked, then the application is not considered alive according to the liveness probe.
-In that case, the platform kills the pod corresponding to that application and recreates a new pod to restart the application.
-
-This use case also allows you to demonstrate and use a readiness probe.
-In cases where the application is running but is unable to handle requests, such as when the application returns an HTTP `503` response code during restart, this application is not considered ready according to the readiness probe.
-If the application is not considered ready by the readiness probe, requests are not routed to that application until it is considered ready according to the readiness probe.
+include::con_purpose-of-the-health-check-pattern.adoc[leveloffset=+1]
 
 include::con_health-check-concepts.adoc[leveloffset=+1]
 

--- a/docs/topics/assembly_http-api-example-application.adoc
+++ b/docs/topics/assembly_http-api-example-application.adoc
@@ -10,14 +10,15 @@
 [id='example-rest-http-{parameter-runtime-anchor}']
 = {name-example-http-api} example for {runtime}
 
-include::rest-level-0-example-intro-paragraph.adoc[]
+Example proficiency level:
 
-This example introduces the mechanics of interacting with a remote service using the HTTP protocol. It allows you to:
+ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
+ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 
-* Execute an HTTP `GET` request on the `api/greeting` endpoint.
-* Receive a response in JSON format with a payload consisting of the `Hello, World!` String.
-* Execute an HTTP `GET` request on the `api/greeting` endpoint while passing in a String argument. This uses the `name` request parameter in the query string.
-* Receive a response in JSON format with a payload of `Hello, $name!` with `$name` replaced by the value of the `name` parameter passed into the request.
+The {name-example-http-api} example shows how to map business operations to a remote procedure call endpoint over HTTP using a REST framework. This corresponds to link:https://martinfowler.com/articles/richardsonMaturityModel.html#level0[Level 0 in the Richardson Maturity Model^].
+Creating an HTTP endpoint using REST and its underlying principles to define your API lets you quickly prototype and design the API flexibly.
+
+include::con_purpose-of-the-http-api-pattern.adoc[leveloffset=+1]
 
 include::proc_viewing-the-example-application-source-code-and-readme.adoc[leveloffset=+1]
 

--- a/docs/topics/assembly_http-api-example-application.adoc
+++ b/docs/topics/assembly_http-api-example-application.adoc
@@ -11,7 +11,6 @@
 = {name-example-http-api} example for {runtime}
 
 Example proficiency level:
-
 ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
 ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
 

--- a/docs/topics/assembly_secured-example-application.adoc
+++ b/docs/topics/assembly_secured-example-application.adoc
@@ -10,23 +10,19 @@
 [id='example-rest-http-secured-{parameter-runtime-anchor}']
 = {name-example-secured} example application for {runtime}
 
-include::note-example-unavailable-oso.adoc[leveloffset=+1]
-
-// When changing this introduction, change also the secured-example-intro-paragraph.adoc file (used by the front-end).
 Example proficiency level:
 xref:proficiency_advanced[*{proficiency-advanced}*].
 
-The {name-example-secured} example application secures a REST endpoint using link:https://access.redhat.com/products/red-hat-single-sign-on[{RHSSO}^]. (This example expands on the {name-example-http-api} example).
-
-{RHSSO}:
-
-* Implements the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html/securing_applications_and_services_guide/openid_connect_3[Open ID Connect] protocol which is an extension of the OAuth 2.0 specification.
-* Issues access tokens to provide clients with various access rights to secured resources.
-
+The {name-example-secured} example application expands on the {name-example-http-api} example application by securing a REST endpoint using link:https://access.redhat.com/products/red-hat-single-sign-on[{RHSSO}^].
+{RHSSO} implements the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html/securing_applications_and_services_guide/openid_connect_3[Open ID Connect] protocol, which is an extension of the OAuth 2.0 specification.
+{RHSSO} issues access tokens that provide clients with various access rights to secured resources.
 Securing an application with SSO enables you to add security to your applications while centralizing the security configuration.
 
-IMPORTANT:  This example comes with {RHSSO} pre-configured for demonstration purposes, it does not explain its principles, usage, or configuration.
+IMPORTANT:  This example comes with {RHSSO} pre-configured for demonstration purposes and does not explain its principles, usage, or configuration.
 Before using this example, ensure that you are familiar with the basic concepts related to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html-single/getting_started_guide/[{RHSSO}^].
+
+include::note-example-unavailable-oso.adoc[leveloffset=+1]
+
 
 include::con_the-secured-project-structure.adoc[leveloffset=+1]
 

--- a/docs/topics/circuit-breaker-example-intro-paragraph.adoc
+++ b/docs/topics/circuit-breaker-example-intro-paragraph.adoc
@@ -1,6 +1,0 @@
-Example proficiency level: 
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
-
-The _Circuit Breaker_ example demonstrates a generic pattern for reporting the failure of a service and then limiting access to the failed service until it becomes available to handle requests. This helps prevent cascading failure in other services that depend on the failed services for functionality.

--- a/docs/topics/con_purpose-of-the-health-check-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-health-check-pattern.adoc
@@ -1,5 +1,5 @@
 [id='purpose-of-the-health-check-pattern_{context}']
-= Purpose of the Health Check Pattern
+= Health check pattern
 
 The purpose of this use case is to demonstrate the health check pattern through the use of probing.
 Probing is used to report the liveness and readiness of an application.

--- a/docs/topics/con_purpose-of-the-health-check-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-health-check-pattern.adoc
@@ -1,0 +1,13 @@
+[id='purpose-of-the-health-check-pattern_{context}']
+= Purpose of the Health Check Pattern
+
+The purpose of this use case is to demonstrate the health check pattern through the use of probing.
+Probing is used to report the liveness and readiness of an application.
+In this use case, you configure an application which exposes an HTTP `health` endpoint to issue HTTP requests.
+If the container is alive, according to the liveness probe on the `health` HTTP endpoint, the management platform receives `200` as return code and no further action is required.
+If the `health` HTTP endpoint does not return a response, for example if the thread is blocked, then the application is not considered alive according to the liveness probe.
+In that case, the platform kills the pod corresponding to that application and recreates a new pod to restart the application.
+
+This use case also allows you to demonstrate and use a readiness probe.
+In cases where the application is running but is unable to handle requests, such as when the application returns an HTTP `503` response code during restart, this application is not considered ready according to the readiness probe.
+If the application is not considered ready by the readiness probe, requests are not routed to that application until it is considered ready according to the readiness probe.

--- a/docs/topics/con_purpose-of-the-http-api-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-http-api-pattern.adoc
@@ -1,5 +1,5 @@
 [id='purpose-of-the-http-api-pattern_{context}']
-= Purpose of the HTTP API Pattern
+= HTTP API pattern
 
 The HTTP API pattern introduces the mechanics of interacting with a remote service using the HTTP protocol. It allows you to:
 

--- a/docs/topics/con_purpose-of-the-http-api-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-http-api-pattern.adoc
@@ -1,0 +1,9 @@
+[id='purpose-of-the-http-api-pattern_{context}']
+= Purpose of the HTTP API Pattern
+
+The HTTP API pattern introduces the mechanics of interacting with a remote service using the HTTP protocol. It allows you to:
+
+* Execute an HTTP `GET` request on the `api/greeting` endpoint.
+* Receive a response in JSON format with a payload consisting of the `Hello, World!` String.
+* Execute an HTTP `GET` request on the `api/greeting` endpoint while passing in a String argument. This uses the `name` request parameter in the query string.
+* Receive a response in JSON format with a payload of `Hello, $name!` with `$name` replaced by the value of the `name` parameter passed into the request.

--- a/docs/topics/con_purpose-of-the-relational-database-backend-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-relational-database-backend-pattern.adoc
@@ -1,7 +1,7 @@
 [id=purpose-of-the-relational-database-backend-pattern_{context}]
 = Purpose of the Relational Database Backend pattern
 
-The example also demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift.
+This example demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift.
 Each runtime shows how to implement the connectivity solution best suited in the given case.
 The runtime can choose between options such as using _JDBC_, _JPA_, or accessing _ORM_ APIs directly.
 

--- a/docs/topics/con_purpose-of-the-relational-database-backend-pattern.adoc
+++ b/docs/topics/con_purpose-of-the-relational-database-backend-pattern.adoc
@@ -1,0 +1,32 @@
+[id=purpose-of-the-relational-database-backend-pattern_{context}]
+= Purpose of the Relational Database Backend pattern
+
+The example also demonstrates the ability of the HTTP application to locate and connect to a database in OpenShift.
+Each runtime shows how to implement the connectivity solution best suited in the given case.
+The runtime can choose between options such as using _JDBC_, _JPA_, or accessing _ORM_ APIs directly.
+
+The example application exposes an HTTP API, which provides endpoints that allow you to manipulate data by performing  _CRUD_ operations over HTTP.
+The _CRUD_ operations are mapped to HTTP `Verbs`.
+The API uses JSON formatting to receive requests and return responses to the user.
+The user can also use a user interface provided by the example to use the application.
+Specifically, this example provides an application that allows you to:
+
+* Navigate to the application web interface in your browser.
+This exposes a simple website allowing you to perform _CRUD_ operations on the data in the `my_data` database.
+* Execute an HTTP `GET` request on the `api/fruits` endpoint.
+* Receive a response formatted as a JSON array containing the list of all fruits in the database.
+* Execute an HTTP `GET` request on the `api/fruits/*` endpoint while passing in a valid item ID as an argument.
+* Receive a response in JSON format containing the name of the fruit with the given ID.
+If no item matches the specified ID, the call results in an HTTP error 404.
+* Execute an HTTP `POST` request on the `api/fruits` endpoint passing in a valid `name` value to create a new entry in the database.
+* Execute an HTTP `PUT` request on the `api/fruits/*` endpoint passing in a valid ID and a name as an argument.
+This updates the name of the item with the given ID to match the name specified in your request.
+* Execute an HTTP `DELETE` request on the `api/fruits/*` endpoint, passing in a valid ID as an argument.
+This removes the item with the specified ID from the database and returns an HTTP code `204` (No Content) as a response.
+If you pass in an invalid ID, the call results in an HTTP error `404`.
+
+ifndef::built-for-nodejs[]
+This example also contains a set of automated xref:running-the-example-application-integration-tests_{context}[integration tests] that can be used to verify that the application is fully integrated with the database.
+endif::built-for-nodejs[]
+
+This example does not showcase a fully matured RESTful model (level 3), but it does use compatible HTTP verbs and status, following the recommended HTTP API practices.

--- a/docs/topics/configmap-example-intro-paragraph.adoc
+++ b/docs/topics/configmap-example-intro-paragraph.adoc
@@ -1,7 +1,0 @@
-Example proficiency level:
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
-
-
-{name-example-configmap} provides a basic example of using a ConfigMap to externalize configuration. _ConfigMap_ is an object used by OpenShift to inject configuration data as simple key and value pairs into one or more Linux containers while keeping the containers independent of OpenShift.

--- a/docs/topics/crud-example-intro-paragraph.adoc
+++ b/docs/topics/crud-example-intro-paragraph.adoc
@@ -1,7 +1,0 @@
-Example proficiency level:
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
-
-.What the {name-example-crud} example does
-The {name-example-crud} example expands on the {name-example-http-api} application to provide a basic example of performing _create_, _read_, _update_ and _delete_ (_CRUD_) operations on a PostgreSQL database using a simple HTTP API. _CRUD_ operations are the four basic functions of persistent storage, widely used when developing an HTTP API dealing with a database.

--- a/docs/topics/health-check-example-intro-paragraph.adoc
+++ b/docs/topics/health-check-example-intro-paragraph.adoc
@@ -1,7 +1,0 @@
-Example proficiency level: 
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
-
-
-When you deploy an application, it is important to know if it is available and if it can start handling incoming requests. Implementing the _health check_ pattern allows you to monitor the health of an application, which includes if an application is available and whether it is able to service requests.

--- a/docs/topics/note-example-unavailable-oso.adoc
+++ b/docs/topics/note-example-unavailable-oso.adoc
@@ -1,3 +1,2 @@
 //IMPORTANT: This example is not currently available on {OpenShiftOnline} Starter. You can still run it using a {OpenShiftLocal}. You can also use a manual workflow to deploy this example to {OpenShiftOnline} Pro and {OpenShiftContainerPlatform}.
-*Limitation:* Run this example application on a {OpenShiftLocal}. You can also use a manual workflow to deploy this example to {OpenShiftOnline} Pro and {OpenShiftContainerPlatform}.
-This example is not currently available on {OpenShiftOnline} Starter.
+*Limitation:* This example is not currently available on {OpenShiftOnline} Starter. Run this example application on a {OpenShiftLocal}. You can also use a manual workflow to deploy this example to {OpenShiftOnline} Pro and {OpenShiftContainerPlatform}.

--- a/docs/topics/rest-level-0-example-intro-paragraph.adoc
+++ b/docs/topics/rest-level-0-example-intro-paragraph.adoc
@@ -1,9 +1,0 @@
-Example proficiency level:
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_foundational[*{proficiency-foundational}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-foundational}*^].]
-
-.What the {name-example-http-api} example does
-
-The {name-example-http-api} example shows how to map business operations to a remote procedure call endpoint over HTTP using a REST framework. This corresponds to link:https://martinfowler.com/articles/richardsonMaturityModel.html#level0[Level 0 in the Richardson Maturity Model^].
-Creating an HTTP endpoint using REST and its underlying principles to define your API lets you quickly prototype and design the API flexibly.

--- a/docs/topics/secured-example-intro-paragraph.adoc
+++ b/docs/topics/secured-example-intro-paragraph.adoc
@@ -1,8 +1,0 @@
-Example proficiency level:
-//special case since topic is used by front end.
-ifdef::docs-topic[xref:proficiency_advanced[*{proficiency-advanced}*].]
-ifndef::docs-topic[link:https://launcher.fabric8.io/docs/thorntail-runtime.html#proficiency_levels[*{proficiency-advanced}*^].]
-
-The {name-example-secured} example application expands on the {name-example-http-api} example application by securing a REST endpoint using link:https://access.redhat.com/products/red-hat-single-sign-on[{RHSSO}^]. {RHSSO} implements the link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html/securing_applications_and_services_guide/openid_connect_3[Open ID Connect] protocol that is an extension of the OAuth 2.0 specification and uses it to issue access tokens to provide clients with various access rights to secured resources. Securing an application with SSO enables you to add security to your applications while centralizing the security configuration.
-
-IMPORTANT:  While this example application comes with {RHSSO} pre-configured for demonstration purposes, it does not explain its principles, usage, or configuration. Before using this example application, ensure that you are familiar with the basic concepts related to link:https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.1/html-single/getting_started_guide/[{RHSSO}^]. 


### PR DESCRIPTION
@tradej @inoxx03 I removed the introductory modules as they are no longer used by the launcher and integrated that content into the assemblies. When the assembly already had content intended to be read after the included intro, I moved that content into a new module. There are some minor content updates. The modules I tend to use for the Launcher capabilities will have additional editorial changes but I will make those changes in separate PRs that correspond to each capability.