### PR TITLE
Address minor issues from QE review feedback on Spring Boot 2.1.6 docs re-release.

### DIFF
--- a/docs/topics/con_server-sent-events.adoc
+++ b/docs/topics/con_server-sent-events.adoc
@@ -4,7 +4,7 @@
 Server-sent events (SSE) is a push technology allowing HTTP sever to send unidirectional updates to the client.
 SSE works by establishing a connection between the event source and the client.
 The event source uses this connection to push events to the client-side.
-After the server pushes the events, the connection remains open, and can be used to push subsequent events.
+After the server pushes the events, the connection remains open and can be used to push subsequent events.
 When the client terminates the request on the server, the connection is closed.
 SSE represents a more resource-efficient alternative to polling, where a new connection must be established each time the client polls the event source for updates.
 As opposed to WebSockets, SSE pushes events in one direction only (that is, from the source to the client).

--- a/docs/topics/con_server-sent-events.adoc
+++ b/docs/topics/con_server-sent-events.adoc
@@ -4,7 +4,7 @@
 Server-sent events (SSE) is a push technology allowing HTTP sever to send unidirectional updates to the client.
 SSE works by establishing a connection between the event source and the client.
 The event source uses this connection to push events to the client-side.
-After the server pushes the events, the connection remains open, and can be used used to push subsequent events.
+After the server pushes the events, the connection remains open, and can be used to push subsequent events.
 When the client terminates the request on the server, the connection is closed.
 SSE represents a more resource-efficient alternative to polling, where a new connection must be established each time the client polls the event source for updates.
 As opposed to WebSockets, SSE pushes events in one direction only (that is, from the source to the client).

--- a/docs/topics/proc_creating-reactive-smtp-email-app.adoc
+++ b/docs/topics/proc_creating-reactive-smtp-email-app.adoc
@@ -38,7 +38,7 @@ include::resources/spring-boot/reactive-examples/example-http-service-mail-handl
 
 . Create the main class of your application:
 +
-.`HttpSecuritySampleApplication.java`
+.`MailSampleApplication.java`
 [source,java,options="nowrap",subs="attributes+"]
 ----
 include::resources/spring-boot/reactive-examples/example-http-mail-service-app.java[]

--- a/docs/topics/proc_using-oauth2-with-reactive-http-web-service-webflux.adoc
+++ b/docs/topics/proc_using-oauth2-with-reactive-http-web-service-webflux.adoc
@@ -54,7 +54,7 @@ include::resources/spring-boot/reactive-examples/example-oauth2-http-webflux-end
 
 . Create the main class of your application:
 +
-.`HttpSecuritySampleApplication.java`
+.`OAuthSampleApplication.java`
 [source,java,options="nowrap",subs="attributes+"]
 ----
 include::resources/spring-boot/reactive-examples/example-oauth2-webflux-application.java[]

--- a/docs/topics/resources/spring-boot/reactive-examples/example-sse-service-sse-controller.java
+++ b/docs/topics/resources/spring-boot/reactive-examples/example-sse-service-sse-controller.java
@@ -1,4 +1,3 @@
-
 package dev.snowdrop.vertx.sample.sse;
 
 import java.time.Duration;
@@ -20,3 +19,4 @@ public class SseController {
             .map(i -> random.nextInt())
             .log();
     }
+}


### PR DESCRIPTION
This PR addresses the following issues raised by QE around the SB 2.1.6 documentation re-relase:
* RHOARDOC-1686: reactive OAuth example: fix classname in label to match classname in code example
* RHOARDOC-1687: reactive Mail example: fix classname in label to match classname in code example
* RHOARDOC-1688: remove duplicate word in Spring reactive concept module about server-sent events
* RHOARDOC-1689: add bracket to properly close `SseController` class definition code example