### PR TITLE
DO NOT MERGE: RHOARDOC-1567 fixed broken xrefs

### DIFF
--- a/docs/topics/proc_git-workflow-for-making-changes.adoc
+++ b/docs/topics/proc_git-workflow-for-making-changes.adoc
@@ -29,12 +29,7 @@ If there are errors in validation, open the `master.xml` file in the directory o
 
 If you are unsure, ask someone from the team for help.
 --
-. Create a pull request against the branch you based your contribution off. Ensure you also:
-+
---
-.. Label the pull request appropriately. For more information about labels, see xref:using-github-labels_{context}[].
-.. Reference the issue that your pull request resolves in the description, using the formulation `resolves $ID`, where `$ID` is the numerical ID of the issue. Doing this automatically closes the issue when the pull request is accepted.
---
+. Create a pull request against the branch you based your contribution off.Reference the issue that your pull request resolves in the description, using the formulation `resolves $ID`, where `$ID` is the numerical ID of the issue. Doing this automatically closes the issue when the pull request is accepted.
 . After your pull request is created, include a link to the edited document in a comment.
 +
 --

--- a/docs/topics/proc_git-workflow-for-making-changes.adoc
+++ b/docs/topics/proc_git-workflow-for-making-changes.adoc
@@ -29,7 +29,7 @@ If there are errors in validation, open the `master.xml` file in the directory o
 
 If you are unsure, ask someone from the team for help.
 --
-. Create a pull request against the branch you based your contribution off.Reference the issue that your pull request resolves in the description, using the formulation `resolves $ID`, where `$ID` is the numerical ID of the issue. Doing this automatically closes the issue when the pull request is accepted.
+. Create a pull request against the branch you based your contribution off.
 . After your pull request is created, include a link to the edited document in a comment.
 +
 --

--- a/docs/topics/ref_jenkins-ci-commands.adoc
+++ b/docs/topics/ref_jenkins-ci-commands.adoc
@@ -6,7 +6,7 @@ As a team member, you can operate the Jenkins continuous integration (CI) system
 By default, only pull requests from trusted collaborators are built automatically.
 You can enable building a particular pull request from an untrusted collaborator or add the pull request author to the list of trusted collaborators.
 
-To issue a command, write it into a comment in a pull request in the link:{link-repo-docs}[{repo-docs-name}^] repository.
+To issue a command, write it into a comment in a pull request in the link:{link-repo-docs}[{name-repo-docs}^] repository.
 Do not write anything else in the comment.
 
 .List of Jenkins commands
@@ -30,4 +30,3 @@ Any future pull requests from the author will be built automatically.
 
 Use this command when a job failed or there is another error.
 |====
-

--- a/docs/topics/ref_rhoardoc-jira-fields.adoc
+++ b/docs/topics/ref_rhoardoc-jira-fields.adoc
@@ -51,7 +51,7 @@ The recommended number of story points _per person per sprint_ is 13 in total.
 Description:: A complete description of the issue.
 
 Status:: The current status of the issue.
-For more information, see xref:rhoardoc-jira-workflow[].
+For more information, see xref:rhoardoc-jira-workflow_{context}[].
 
 Resolution:: How the issue was resolved.
 +
@@ -67,4 +67,3 @@ Due Date:: A specific date before which the issue should be resolved.
 +
 If not set, check the linked epic or parent issue if any.
 They might have a Due Date set.
-


### PR DESCRIPTION
to attribute :rhoardoc-jira-workflow: was added missing ending _context
the attribute :using-github-labels_contributing: doesn't exist,therefore all referring information was deleted
the name of attribute :repo-docs-name: was changed to :name-repo-docs: