### PR TITLE
Remove references to product name and abbreviations form Launcher docs

### DIFF
--- a/docs/topics/assembly_developing-and-deploying-spring-reactive-application.adoc
+++ b/docs/topics/assembly_developing-and-deploying-spring-reactive-application.adoc
@@ -5,7 +5,7 @@
 
 NOTE: {VertX} reactive components for {SpringBoot} are provided as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
 
-This section provides an introduction to developing applications in a reactive way using {ProductShortName} {SpringBoot} starters based on {SpringBoot} and {VertX}.
+This section provides an introduction to developing applications in a reactive way using {SpringBoot} starters based on {SpringBoot} and {VertX}.
 The following examples demonstrate how you can use the starters to create reactive applications.
 
 include::con_spring-reactive-introduction.adoc[leveloffset=+1]

--- a/docs/topics/ref_additional-vertx-resources.adoc
+++ b/docs/topics/ref_additional-vertx-resources.adoc
@@ -4,7 +4,7 @@
 * link:https://www.reactivemanifesto.org/[The Reactive Manifesto]
 * link:http://vertx.io[{VertX} project]
 * link:https://www.manning.com/books/vertx-in-action[Vert.x in Action]
-* link:http://middlewareblog.redhat.com/2017/05/04/vert-x-for-reactive-programming-in-red-hat-openshift-application-runtimes/[{VertX} for Reactive Programming in Red Hat OpenShift Application Runtimes]
+* link:http://middlewareblog.redhat.com/2017/05/04/vert-x-for-reactive-programming-in-red-hat-openshift-application-runtimes/[{VertX} for Reactive Programming]
 * link:https://developers.redhat.com/promotions/building-reactive-microservices-in-java/[Building Reactive Microservices in Java]
 * link:https://developers.redhat.com/promotions/vertx-cheatsheet/[{VertX} Cheat Sheet for Developers]
 * link:http://escoffier.me/vertx-hol/#_vert_x[Vert.x - From zero to (micro)-hero]

--- a/docs/topics/ref_application-development-resources.adoc
+++ b/docs/topics/ref_application-development-resources.adoc
@@ -4,9 +4,8 @@
 For additional information about application development with OpenShift, see:
 
 * link:https://learn.openshift.com/[OpenShift Interactive Learning Portal^]
-* link:https://developers.redhat.com/products/rhoar/overview/[Red Hat OpenShift Application Runtimes Overview^]
+//* link:https://developers.redhat.com/products/rhoar/overview/[Red Hat Runtimes Overview^]
 
 To reduce network load and shorten the build time of your application, set up a Nexus mirror for Maven on your {OpenShiftLocal}:
 
 * link:https://docs.openshift.com/container-platform/3.11/dev_guide/dev_tutorials/maven_tutorial.html[Setting Up a Nexus Mirror for Maven^]
-

--- a/docs/topics/ref_community-and-product-versions-of-vertx.adoc
+++ b/docs/topics/ref_community-and-product-versions-of-vertx.adoc
@@ -8,6 +8,6 @@ Supported {Vertx} runtime artifacts are available in the link:https://maven.repo
 
 .Technology Preview {Vertx} Components
 
-Technology Preview {Vertx} components included with {ProductShortName} are not supported. The supportability of these components is defined by the link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope^].
+Red Hat does not provide full support for Technology Preview {Vertx} components. The supportability of such components is defined by the link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope^].
 
-For a complete list of supported and Technology Preview {Vertx} components available with this release of {ProductShortName}, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/#rn-runtime-components-vertx[Release Notes^].
+For a complete list of {Vertx} components provided by Red Hat, both supported and Technology Preview, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_application_runtimes/1/html-single/red_hat_openshift_application_runtimes_release_notes/#rn-runtime-components-vertx[Release Notes^].

--- a/docs/topics/templates/document-attributes-launcher.adoc
+++ b/docs/topics/templates/document-attributes-launcher.adoc
@@ -3,7 +3,6 @@
 :docinfo1:
 
 :ProductName: Application Development on OpenShift
-:ProductShortName: {ProductName}
 
 :imagesdir: images
 

--- a/docs/topics/templates/document-attributes-portal.adoc
+++ b/docs/topics/templates/document-attributes-portal.adoc
@@ -2,7 +2,6 @@
 :imagesdir: topics/images
 
 :ProductName: Red Hat OpenShift Application Runtimes
-:ProductShortName: RHOAR
 :ProductRelease: 1
 :ProductVersion: 1
 :DocInfoProductNumber: 1
@@ -19,4 +18,3 @@
 :link-guide-nodejs: {portal-base-url}/node.js_runtime_guide/
 
 :link-launcher-yaml: https://launcher.fabric8.io/latest-launcher-template
-

--- a/docs/topics/templates/document-attributes-portal.adoc
+++ b/docs/topics/templates/document-attributes-portal.adoc
@@ -1,7 +1,7 @@
 
 :imagesdir: topics/images
 
-:ProductName: Red Hat OpenShift Application Runtimes
+//:ProductName: Red Hat OpenShift Application Runtimes
 :ProductRelease: 1
 :ProductVersion: 1
 :DocInfoProductNumber: 1


### PR DESCRIPTION
NOTE: some instance of product name and acronym remain in place, these instances appear in the Getting Started Guide and Minishift installation guide, both of which will be abandoned and refactored into a new title as part of the restructure.