### PR TITLE
chore: update references of rhoar nodejs image to software collections

### DIFF
--- a/docs/topics/proc_configuring-jenkins-freestyle-project-to-deploy-nodejs-application-with-nodeshift.adoc
+++ b/docs/topics/proc_configuring-jenkins-freestyle-project-to-deploy-nodejs-application-with-nodeshift.adoc
@@ -12,7 +12,7 @@ Similar to using nodeshift from your local host to deploy a {Node} application, 
 .Example using the Red Hat base image with nodeshift
 [source,bash,options="nowrap",subs="attributes+"]
 ----
-$ nodeshift --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8 ...
+$ nodeshift --dockerImage=registry.access.redhat.com/rhscl/nodejs-10-rhel7 ...
 ----
 * The source of the application available in GitHub.
 
@@ -37,7 +37,7 @@ For example, if you configured a service account for Jenkins, ensure that accoun
 [source,bash,options="nowrap",subs="attributes+"]
 ----
 npm install -g nodeshift
-nodeshift --strictSSL=false --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8 --namespace=MY_PROJECT
+nodeshift --dockerImage=registry.access.redhat.com/rhscl/nodejs-10-rhel7 --namespace=MY_PROJECT
 ----
 +
 Substitute `MY_PROJECT` with the name of the OpenShift project for your application.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -82,7 +82,7 @@ endif::[]
 :version-vertx: 3.8.1.redhat-00005
 :version-vertx-maven-plugin: 1.0.20
 
-:option-base-image-node: --dockerImage=registry.access.redhat.com/rhoar-nodejs/nodejs-8
+:option-base-image-node: --dockerImage=registry.access.redhat.com/rhscl/nodejs-10-rhel7
 
 // Prerequisites
 :prerequisite-jdk-version: OpenJDK 8 or OpenJDK 11 installed.


### PR DESCRIPTION
We are in the process of migrating the rhoar nodejs images to the images provided by RHSCL

I think i found all the references