### PR TITLE
update saas template to use serviceAccount reference for pullSecrets

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -119,6 +119,8 @@ objects:
         dnsPolicy: ClusterFirst
         securityContext: {}
         terminationGracePeriodSeconds: 30
+        serviceAccount: dsaas-deploy
+        serviceAccountName: dsaas-deploy
     test: false
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
this is needed for dsaas+osd4 compatibility, same thing as https://github.com/fabric8-launcher/launcher-application/pull/1025

@inoxx03 / @quintesse ptal! thanks.